### PR TITLE
feat(files): add file deletion functionality

### DIFF
--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -10,7 +10,7 @@ export type File = z.infer<typeof fileSchema>
 
 export const eventSchema = z.object({
   event_id: z.string(),
-  event_type: z.literal("FILE_UPDATED"),
+  event_type: z.union([z.literal("FILE_UPDATED"), z.literal("FILE_DELETED")]),
   file_path: z.string(),
   created_at: z.string(),
 })

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@tscircuit/file-server",
   "main": "./dist/bundle.js",
   "type": "module",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "bin": {
     "file-server": "./dist/cli.js"
   },

--- a/routes/files/delete.ts
+++ b/routes/files/delete.ts
@@ -14,7 +14,17 @@ export default withRouteSpec({
     }),
   jsonResponse: z.union([z.null(), z.object({ error: z.string() })]),
 })(async (req, ctx) => {
-  const { file_id, file_path, initiator } = req.jsonBody
+  const body = await req.json()
+  const file_id = body?.file_id
+  const file_path = body?.file_path
+  const initiator = body?.initiator
+
+  if (!file_id && !file_path) {
+    return ctx.json(
+      { error: "Either file_id or file_path must be provided" },
+      { status: 400 },
+    )
+  }
 
   const deletedFile = ctx.db.deleteFile({ file_id, file_path }, { initiator })
 

--- a/routes/files/delete.ts
+++ b/routes/files/delete.ts
@@ -2,22 +2,15 @@ import { withRouteSpec } from "lib/middleware/with-winter-spec"
 import { z } from "zod"
 
 export default withRouteSpec({
-  methods: ["DELETE"],
-  jsonBody: z
-    .object({
-      file_id: z.string().optional(),
-      file_path: z.string().optional(),
-      initiator: z.string().optional(),
-    })
-    .refine((data) => data.file_id || data.file_path, {
-      message: "Either file_id or file_path must be provided",
-    }),
+  methods: ["POST", "DELETE"],
+  commonParams: z.object({
+    file_id: z.string().optional(),
+    file_path: z.string().optional(),
+    initiator: z.string().optional(),
+  }),
   jsonResponse: z.union([z.null(), z.object({ error: z.string() })]),
 })(async (req, ctx) => {
-  const body = await req.json()
-  const file_id = body?.file_id
-  const file_path = body?.file_path
-  const initiator = body?.initiator
+  const { file_id, file_path, initiator } = req.commonParams
 
   if (!file_id && !file_path) {
     return ctx.json(

--- a/routes/files/delete.ts
+++ b/routes/files/delete.ts
@@ -1,0 +1,26 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["DELETE"],
+  jsonBody: z
+    .object({
+      file_id: z.string().optional(),
+      file_path: z.string().optional(),
+      initiator: z.string().optional(),
+    })
+    .refine((data) => data.file_id || data.file_path, {
+      message: "Either file_id or file_path must be provided",
+    }),
+  jsonResponse: z.union([z.null(), z.object({ error: z.string() })]),
+})(async (req, ctx) => {
+  const { file_id, file_path, initiator } = req.jsonBody
+
+  const deletedFile = ctx.db.deleteFile({ file_id, file_path }, { initiator })
+
+  if (!deletedFile) {
+    return ctx.json({ error: "File not found" }, { status: 404 })
+  }
+
+  return ctx.json(null, { status: 204 })
+})

--- a/tests/routes/files.test.ts
+++ b/tests/routes/files.test.ts
@@ -126,7 +126,7 @@ test("file delete operations", async () => {
 
   eventsRes = await axios.get("/events/list")
   const deleteEventId = eventsRes.data.event_list.find(
-    (e: any) => e.event_type === "FILE_DELETED" && e.file_id === fileIdToDelete,
+    (e: any) => e.event_type === "FILE_DELETED" && e.file_path === filePathById,
   )
   expect(deleteEventId).toBeDefined()
   expect(deleteEventId.file_path).toBe(filePathById)

--- a/tests/routes/files.test.ts
+++ b/tests/routes/files.test.ts
@@ -89,8 +89,9 @@ test("file delete operations", async () => {
   })
   const filePathToDelete = createResPath.data.file.file_path
 
-  const deleteResPath = await axios.delete("/files/delete", {
-    data: { file_path: filePathToDelete, initiator: "test-path-delete" },
+  const deleteResPath = await axios.post("/files/delete", {
+    file_path: filePathToDelete,
+    initiator: "test-path-delete",
   })
   expect(deleteResPath.status).toBe(204)
 
@@ -114,8 +115,8 @@ test("file delete operations", async () => {
   const fileIdToDelete = createResId.data.file.file_id
   const filePathById = createResId.data.file.file_path
 
-  const deleteResId = await axios.delete("/files/delete", {
-    data: { file_id: fileIdToDelete },
+  const deleteResId = await axios.post("/files/delete", {
+    file_id: fileIdToDelete,
   })
   expect(deleteResId.status).toBe(204)
 
@@ -133,7 +134,9 @@ test("file delete operations", async () => {
 
   expect(
     axios.delete("/files/delete", {
-      data: { file_path: "/non-existent-path.txt" },
+      data: {
+        file_path: "/non-existent-path.txt",
+      },
     }),
   ).rejects.toMatchObject({
     status: 404,
@@ -141,8 +144,8 @@ test("file delete operations", async () => {
   })
 
   expect(
-    axios.delete("/files/delete", {
-      data: { file_id: "non-existent-id" },
+    axios.post("/files/delete", {
+      file_id: "non-existent-id",
     }),
   ).rejects.toMatchObject({
     status: 404,


### PR DESCRIPTION
Introduce a new DELETE endpoint for file deletion, supporting deletion by file_id or file_path. The deletion triggers a FILE_DELETED event. Added corresponding tests to verify successful deletions, error handling, and event creation.


fix #12 