### PR TITLE
Add support for HTTP/2

### DIFF
--- a/routes/proxy.ts
+++ b/routes/proxy.ts
@@ -38,7 +38,9 @@ export default withRouteSpec({
 
   const senderHost = req.headers.get("X-Sender-Host")
   if (senderHost) {
-    headers.set("Host", senderHost)
+    const hostValue = senderHost.replace(/^https?:\/\//, "")
+    headers.set("Host", hostValue)
+    headers.set("authority", hostValue)
   }
 
   // Add support for X-Sender-Referer


### PR DESCRIPTION
The browser uses the HTTP/1 which works with the `host` header, but the node fetch uses the HTTP/2 which requires the `authority` header being passed without the protocol value being passed to it