### PR TITLE
feat: show file download links in admin page

### DIFF
--- a/routes/admin/files/get.ts
+++ b/routes/admin/files/get.ts
@@ -37,6 +37,11 @@ export default withRouteSpec({
           <p><span class="label">File Path:</span> ${file.file_path}</p>
           <p><span class="label">Created At:</span> ${file.created_at}</p>
         </div>
+        <h2>Links:</h2>
+        <ul>
+          <li><a href="../../files/download?file_path=/${file.file_path}">Download File</a></li>
+          <li><a href="../../files/static/${file.file_path}">Static Route</a></li>
+        </ul>
         <h2>Content:</h2>
         <pre>${(file.text_content ?? "[binary content]")
           .replace(/&/g, "&amp;")

--- a/tests/routes/admin-files-page.test.ts
+++ b/tests/routes/admin-files-page.test.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("admin file page shows download and static links", async () => {
+  const { axios } = await getTestServer()
+
+  await axios.post("/files/upsert", {
+    file_path: "/admin-link-test.txt",
+    text_content: "hello",
+  })
+
+  const res = await axios.get("/admin/files/get", {
+    params: { file_path: "/admin-link-test.txt" },
+  })
+
+  const html = res.data as string
+  expect(html).toContain(
+    'href="../../files/download?file_path=/admin-link-test.txt"',
+  )
+  expect(html).toContain('href="../../files/static/admin-link-test.txt"')
+})


### PR DESCRIPTION
## Summary
- show download and static file links on admin file details page
- use relative paths for these links to support proxies with path prefixes
- test that admin page includes these relative links

## Testing
- `bunx tsc --noEmit`
- `bun test tests/routes/admin-files-page.test.ts`
- `bun test tests/routes/files.test.ts`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68c5a9495d00832e84470ae6bb817cf3