### PR TITLE
fix: support nested paths in static route

### DIFF
--- a/routes/files/static/[[...file_path]].ts
+++ b/routes/files/static/[[...file_path]].ts
@@ -50,11 +50,18 @@ const getMimeType = (filePath: string): string => {
 export default withRouteSpec({
   methods: ["GET"],
   pathParams: z.object({
-    file_path: z.string(),
+    file_path: z.union([z.string(), z.array(z.string())]),
   }),
 })((req, ctx) => {
-  const { file_path } = req.routeParams as { file_path: string }
-  const file = ctx.db.getFile({ file_path: `/${file_path}` })
+  const { file_path } = req.routeParams as {
+    file_path: string | string[]
+  }
+
+  const joinedFilePath = Array.isArray(file_path)
+    ? file_path.join("/")
+    : file_path
+
+  const file = ctx.db.getFile({ file_path: `/${joinedFilePath}` })
 
   if (!file) {
     return new Response("File not found", { status: 404 })

--- a/tests/routes/files.test.ts
+++ b/tests/routes/files.test.ts
@@ -299,6 +299,11 @@ test("file static serving operations", async () => {
       content: "unknown file type",
       expectedMime: "application/octet-stream",
     },
+    {
+      path: "/example-dir2/myObj.obj",
+      content: "fake obj content",
+      expectedMime: "application/octet-stream",
+    },
   ]
 
   for (const file of testFiles) {


### PR DESCRIPTION
## Summary
- handle nested file paths in static route
- test static file serving with nested path

## Testing
- `bunx tsc --noEmit`
- `bun test tests/routes/files.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68c5b180c2d0832ea29d14c2c30b46e1