### PR TITLE
Fix binary responses and add coverage

### DIFF
--- a/lib/utils/decode-base64.ts
+++ b/lib/utils/decode-base64.ts
@@ -1,0 +1,12 @@
+import { Buffer } from "node:buffer"
+
+export const decodeBase64ToUint8Array = (base64: string): Uint8Array => {
+  const buffer = Buffer.from(base64, "base64")
+  return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+}
+
+export const uint8ArrayToArrayBuffer = (view: Uint8Array): ArrayBuffer => {
+  const buffer = new ArrayBuffer(view.byteLength)
+  new Uint8Array(buffer).set(view)
+  return buffer
+}

--- a/routes/files/download.ts
+++ b/routes/files/download.ts
@@ -1,6 +1,9 @@
 import { withRouteSpec } from "lib/middleware/with-winter-spec"
 import { z } from "zod"
-import { Buffer } from "node:buffer"
+import {
+  decodeBase64ToUint8Array,
+  uint8ArrayToArrayBuffer,
+} from "lib/utils/decode-base64"
 
 export default withRouteSpec({
   methods: ["GET"],
@@ -17,13 +20,23 @@ export default withRouteSpec({
   }
 
   const isText = file.text_content !== undefined
-  const body = isText
-    ? file.text_content
-    : Buffer.from(file.binary_content_b64!, "base64")
+  if (!isText && file.binary_content_b64) {
+    const binaryBody = decodeBase64ToUint8Array(file.binary_content_b64)
+    const responseBody = uint8ArrayToArrayBuffer(binaryBody)
+    return new Response(responseBody, {
+      headers: {
+        "Content-Type": "application/octet-stream",
+        "Content-Disposition": `attachment; filename="${file.file_path
+          .split("/")
+          .pop()}"`,
+        "Content-Length": binaryBody.byteLength.toString(),
+      },
+    })
+  }
 
-  return new Response(body, {
+  return new Response(file.text_content!, {
     headers: {
-      "Content-Type": isText ? "text/plain" : "application/octet-stream",
+      "Content-Type": "text/plain",
       "Content-Disposition": `attachment; filename="${file.file_path
         .split("/")
         .pop()}"`,


### PR DESCRIPTION
## Summary
- ensure binary file endpoints return ArrayBuffer payloads with explicit content-length headers
- add a utility for decoding base64 content into Uint8Array bodies
- expand tests to cover high-bit binary payloads and verify response headers

## Testing
- bun test tests/routes/files.test.ts
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68c8e81f27b0832eaa63672dc7ffb99d