### PR TITLE
Add coverage and docs for download endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ The server persists the binary payload exactly as provided. When retrieving the
 file with `/files/get`, the same `binary_content_b64` string will be returned
 and can be decoded back to the original bytes in your client code.
 
+#### Download File
+
+```http
+GET /files/download?file_id=1
+# or
+GET /files/download?file_path=path/to/file.txt
+# or
+GET /files/download/path/to/file.txt
+```
+
+Returns the file body directly with `Content-Disposition: attachment` so clients
+can save the file.
+
 #### Get File
 
 ```http

--- a/routes/index.ts
+++ b/routes/index.ts
@@ -13,6 +13,8 @@ This is a simple file server API, it has the following API:
 
 /health - Health check
 /files/get?file_path=... - Get a file
+/files/download?file_path=... - Download a file
+/files/download/{file_path} - Download a file by path URL
 /files/list - List all files
 /files/upsert - Upsert a file
 

--- a/tests/routes/files.test.ts
+++ b/tests/routes/files.test.ts
@@ -112,6 +112,44 @@ test("file download operations2", async () => {
   })
 })
 
+
+test("file download supports query by file_id and nested path URLs", async () => {
+  const { axios } = await getTestServer()
+
+  const upsertTextRes = await axios.post("/files/upsert", {
+    file_path: "/nested/path/manual.txt",
+    text_content: "Nested text file",
+  })
+
+  const byIdRes = await axios.get("/files/download", {
+    params: { file_id: upsertTextRes.data.file.file_id },
+  })
+  expect(byIdRes.status).toBe(200)
+  expect(byIdRes.data).toBe("Nested text file")
+  expect(byIdRes.headers.get("content-disposition")).toBe(
+    'attachment; filename="manual.txt"',
+  )
+
+  const byPathUrlRes = await axios.get("/files/download/nested/path/manual.txt")
+  expect(byPathUrlRes.status).toBe(200)
+  expect(byPathUrlRes.data).toBe("Nested text file")
+
+  const binary = Buffer.from([222, 173, 190, 239])
+  await axios.post("/files/upsert", {
+    file_path: "/nested/path/data.bin",
+    binary_content_b64: binary.toString("base64"),
+  })
+
+  const binaryByPathRes = await axios.get("/files/download/nested/path/data.bin", {
+    responseType: "arrayBuffer",
+  })
+  expect(binaryByPathRes.status).toBe(200)
+  expect(Buffer.from(binaryByPathRes.data)).toEqual(binary)
+  expect(binaryByPathRes.headers.get("content-type")).toBe(
+    "application/octet-stream",
+  )
+})
+
 test("file delete operations", async () => {
   const { axios } = await getTestServer()
 


### PR DESCRIPTION
Adds focused coverage and docs for the download URL patterns from #5.

### What changed
- Added tests for `/files/download` query usage by `file_id`
- Added tests for nested path URL usage via `/files/download/{file_path}` (text + binary)
- Documented both download endpoint styles in README
- Added download routes to the root API index page

### Validation
- `bun test`

/claim #5