### PR TITLE
fix: add ky-backed download endpoint coverage

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,11 +1,11 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@tscircuit/file-server",
       "dependencies": {
         "winterspec": "^0.0.86",
-        "zod": "^3.23.8",
         "zustand": "^4.5.5",
         "zustand-hoist": "^2.0.1",
       },
@@ -13,12 +13,14 @@
         "@biomejs/biome": "^1.8.3",
         "@types/bun": "latest",
         "@types/react": "18.3.4",
+        "ky": "^1.8.1",
         "next": "^14.2.5",
-        "redaxios": "^0.5.1",
         "tsup": "^8.3.5",
+        "zod": "^3.23.8",
       },
       "peerDependencies": {
         "typescript": "^5.0.0",
+        "zod": "*",
       },
     },
   },
@@ -325,6 +327,8 @@
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
+    "ky": ["ky@1.14.3", "", {}, "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw=="],
+
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
@@ -412,8 +416,6 @@
     "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
-
-    "redaxios": ["redaxios@0.5.1", "", {}, "sha512-FSD2AmfdbkYwl7KDExYQlVvIrFz6Yd83pGfaGjBzM9F6rpq8g652Q4Yq5QD4c+nf4g2AgeElv1y+8ajUPiOYMg=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@types/bun": "latest",
     "@types/react": "18.3.4",
     "next": "^14.2.5",
-    "redaxios": "^0.5.1",
+    "ky": "^1.8.1",
     "tsup": "^8.3.5",
     "zod": "^3.23.8"
   },

--- a/tests/fixtures/get-test-server.ts
+++ b/tests/fixtures/get-test-server.ts
@@ -1,12 +1,12 @@
 import { afterEach } from "bun:test"
 import { tmpdir } from "node:os"
-import defaultAxios from "redaxios"
+import ky from "ky"
 import { startServer } from "./start-server"
 
 interface TestFixture {
   url: string
   server: any
-  axios: typeof defaultAxios
+  ky: typeof ky
 }
 
 export const getTestServer = async (): Promise<TestFixture> => {
@@ -20,8 +20,9 @@ export const getTestServer = async (): Promise<TestFixture> => {
   })
 
   const url = `http://127.0.0.1:${port}`
-  const axios = defaultAxios.create({
-    baseURL: url,
+  const kyInstance = ky.create({
+    prefixUrl: url,
+    throwHttpErrors: false,
   })
 
   afterEach(async () => {
@@ -32,6 +33,6 @@ export const getTestServer = async (): Promise<TestFixture> => {
   return {
     url,
     server,
-    axios,
+    ky: kyInstance,
   }
 }

--- a/tests/routes/admin-files-page.test.ts
+++ b/tests/routes/admin-files-page.test.ts
@@ -2,18 +2,21 @@ import { test, expect } from "bun:test"
 import { getTestServer } from "tests/fixtures/get-test-server"
 
 test("admin file page shows download and static links", async () => {
-  const { axios } = await getTestServer()
+  const { ky } = await getTestServer()
 
-  await axios.post("/files/upsert", {
-    file_path: "/admin-link-test.txt",
-    text_content: "hello",
+  await ky.post("files/upsert", {
+    json: {
+      file_path: "/admin-link-test.txt",
+      text_content: "hello",
+    },
   })
 
-  const res = await axios.get("/admin/files/get", {
-    params: { file_path: "/admin-link-test.txt" },
-  })
+  const html = await ky
+    .get("admin/files/get", {
+      searchParams: { file_path: "/admin-link-test.txt" },
+    })
+    .text()
 
-  const html = res.data as string
   expect(html).toContain(
     'href="../../files/download?file_path=/admin-link-test.txt"',
   )

--- a/tests/routes/events.test.ts
+++ b/tests/routes/events.test.ts
@@ -38,9 +38,7 @@ test("filter events by event_type", async () => {
     json: { event_type: "USER_LOGOUT", user_id: "123" },
   })
 
-  const listAllData = await ky
-    .get("events/list")
-    .json<{ event_list: any[] }>()
+  const listAllData = await ky.get("events/list").json<{ event_list: any[] }>()
   expect(listAllData.event_list).toHaveLength(2)
 
   const filteredData = await ky

--- a/tests/routes/events.test.ts
+++ b/tests/routes/events.test.ts
@@ -2,9 +2,8 @@ import { test, expect } from "bun:test"
 import { getTestServer } from "tests/fixtures/get-test-server"
 
 test("custom events", async () => {
-  const { axios } = await getTestServer()
+  const { ky } = await getTestServer()
 
-  // Create a custom event
   const customEvent = {
     event_type: "USER_LOGIN",
     user_id: "123",
@@ -12,15 +11,16 @@ test("custom events", async () => {
     success: true,
   }
 
-  const createRes = await axios.post("/events/create", customEvent)
-  expect(createRes.data.event.event_type).toBe("USER_LOGIN")
-  expect(createRes.data.event.user_id).toBe("123")
-  expect(createRes.data.event.ip_address).toBe("192.168.1.1")
-  expect(createRes.data.event.success).toBe(true)
+  const createData = await ky
+    .post("events/create", { json: customEvent })
+    .json<{ event: typeof customEvent }>()
+  expect(createData.event.event_type).toBe("USER_LOGIN")
+  expect(createData.event.user_id).toBe("123")
+  expect(createData.event.ip_address).toBe("192.168.1.1")
+  expect(createData.event.success).toBe(true)
 
-  // Verify event is in the list
-  const listRes = await axios.get("/events/list")
-  const createdEvent = listRes.data.event_list[0]
+  const listData = await ky.get("events/list").json<{ event_list: any[] }>()
+  const createdEvent = listData.event_list[0]
   expect(createdEvent.event_type).toBe("USER_LOGIN")
   expect(createdEvent.user_id).toBe("123")
   expect(createdEvent.ip_address).toBe("192.168.1.1")
@@ -28,52 +28,48 @@ test("custom events", async () => {
 })
 
 test("filter events by event_type", async () => {
-  const { axios } = await getTestServer()
+  const { ky } = await getTestServer()
 
-  await axios.post("/events/create", {
-    event_type: "USER_LOGIN",
-    user_id: "123",
+  await ky.post("events/create", {
+    json: { event_type: "USER_LOGIN", user_id: "123" },
   })
 
-  await axios.post("/events/create", {
-    event_type: "USER_LOGOUT",
-    user_id: "123",
+  await ky.post("events/create", {
+    json: { event_type: "USER_LOGOUT", user_id: "123" },
   })
 
-  const listAllRes = await axios.get("/events/list")
-  expect(listAllRes.data.event_list).toHaveLength(2)
+  const listAllData = await ky
+    .get("events/list")
+    .json<{ event_list: any[] }>()
+  expect(listAllData.event_list).toHaveLength(2)
 
-  const filteredRes = await axios.get("/events/list", {
-    params: { event_type: "USER_LOGIN" },
-  })
+  const filteredData = await ky
+    .get("events/list", {
+      searchParams: { event_type: "USER_LOGIN" },
+    })
+    .json<{ event_list: any[] }>()
 
-  expect(filteredRes.data.event_list).toHaveLength(1)
-  expect(filteredRes.data.event_list[0].event_type).toBe("USER_LOGIN")
-  expect(filteredRes.data.event_list[0].user_id).toBe("123")
+  expect(filteredData.event_list).toHaveLength(1)
+  expect(filteredData.event_list[0].event_type).toBe("USER_LOGIN")
+  expect(filteredData.event_list[0].user_id).toBe("123")
 })
 
 test("reset events", async () => {
-  const { axios } = await getTestServer()
+  const { ky } = await getTestServer()
 
-  // Create some events
-  await axios.post("/events/create", {
-    event_type: "USER_LOGIN",
-    user_id: "123",
+  await ky.post("events/create", {
+    json: { event_type: "USER_LOGIN", user_id: "123" },
   })
-  await axios.post("/events/create", {
-    event_type: "USER_LOGIN",
-    user_id: "456",
+  await ky.post("events/create", {
+    json: { event_type: "USER_LOGIN", user_id: "456" },
   })
 
-  // Verify events exist
-  let listRes = await axios.get("/events/list")
-  expect(listRes.data.event_list).toHaveLength(2)
+  let listData = await ky.get("events/list").json<{ event_list: any[] }>()
+  expect(listData.event_list).toHaveLength(2)
 
-  // Reset events
-  const resetRes = await axios.post("/events/reset")
-  expect(resetRes.data.ok).toBe(true)
+  const resetData = await ky.post("events/reset").json<{ ok: boolean }>()
+  expect(resetData.ok).toBe(true)
 
-  // Verify events are cleared
-  listRes = await axios.get("/events/list")
-  expect(listRes.data.event_list).toHaveLength(0)
+  listData = await ky.get("events/list").json<{ event_list: any[] }>()
+  expect(listData.event_list).toHaveLength(0)
 })

--- a/tests/routes/file-proxy01.test.ts
+++ b/tests/routes/file-proxy01.test.ts
@@ -66,8 +66,12 @@ test("file proxy CRUD operations", async () => {
   const listData = await listRes.json<any>()
   expect(listData.file_proxies).toHaveLength(2)
 
-  const diskProxy = listData.file_proxies.find((p: any) => p.proxy_type === "disk")
-  const httpProxy = listData.file_proxies.find((p: any) => p.proxy_type === "http")
+  const diskProxy = listData.file_proxies.find(
+    (p: any) => p.proxy_type === "disk",
+  )
+  const httpProxy = listData.file_proxies.find(
+    (p: any) => p.proxy_type === "http",
+  )
   expect(diskProxy).toBeDefined()
   expect(httpProxy).toBeDefined()
 })

--- a/tests/routes/file-proxy01.test.ts
+++ b/tests/routes/file-proxy01.test.ts
@@ -2,94 +2,93 @@ import { test, expect } from "bun:test"
 import { getTestServer } from "tests/fixtures/get-test-server"
 
 test("file proxy CRUD operations", async () => {
-  const { axios } = await getTestServer()
+  const { ky } = await getTestServer()
 
-  // Create a disk proxy
-  const createDiskRes = await axios.post("/file_proxies/create", {
-    proxy_type: "disk",
-    disk_path: "/tmp/test-files",
-    matching_pattern: "local/*",
+  const createDiskRes = await ky.post("file_proxies/create", {
+    json: {
+      proxy_type: "disk",
+      disk_path: "/tmp/test-files",
+      matching_pattern: "local/*",
+    },
   })
   expect(createDiskRes.status).toBe(200)
-  expect(createDiskRes.data.file_proxy.proxy_type).toBe("disk")
-  expect(createDiskRes.data.file_proxy.disk_path).toBe("/tmp/test-files")
-  expect(createDiskRes.data.file_proxy.matching_pattern).toBe("local/*")
-  expect(createDiskRes.data.file_proxy.file_proxy_id).toBeDefined()
-  expect(createDiskRes.data.file_proxy.created_at).toBeDefined()
+  const createDiskData = await createDiskRes.json<any>()
+  expect(createDiskData.file_proxy.proxy_type).toBe("disk")
+  expect(createDiskData.file_proxy.disk_path).toBe("/tmp/test-files")
+  expect(createDiskData.file_proxy.matching_pattern).toBe("local/*")
+  expect(createDiskData.file_proxy.file_proxy_id).toBeDefined()
+  expect(createDiskData.file_proxy.created_at).toBeDefined()
 
-  const diskProxyId = createDiskRes.data.file_proxy.file_proxy_id
+  const diskProxyId = createDiskData.file_proxy.file_proxy_id
 
-  // Create an HTTP proxy
-  const createHttpRes = await axios.post("/file_proxies/create", {
-    proxy_type: "http",
-    http_target_url: "https://example.com/files",
-    matching_pattern: "remote/*",
+  const createHttpRes = await ky.post("file_proxies/create", {
+    json: {
+      proxy_type: "http",
+      http_target_url: "https://example.com/files",
+      matching_pattern: "remote/*",
+    },
   })
   expect(createHttpRes.status).toBe(200)
-  expect(createHttpRes.data.file_proxy.proxy_type).toBe("http")
-  expect(createHttpRes.data.file_proxy.http_target_url).toBe(
+  const createHttpData = await createHttpRes.json<any>()
+  expect(createHttpData.file_proxy.proxy_type).toBe("http")
+  expect(createHttpData.file_proxy.http_target_url).toBe(
     "https://example.com/files",
   )
-  expect(createHttpRes.data.file_proxy.matching_pattern).toBe("remote/*")
+  expect(createHttpData.file_proxy.matching_pattern).toBe("remote/*")
 
-  const httpProxyId = createHttpRes.data.file_proxy.file_proxy_id
+  const httpProxyId = createHttpData.file_proxy.file_proxy_id
 
-  // Get proxy by ID
-  const getByIdRes = await axios.get("/file_proxies/get", {
-    params: { file_proxy_id: diskProxyId },
+  const getByIdRes = await ky.get("file_proxies/get", {
+    searchParams: { file_proxy_id: diskProxyId },
   })
   expect(getByIdRes.status).toBe(200)
-  expect(getByIdRes.data.file_proxy.file_proxy_id).toBe(diskProxyId)
-  expect(getByIdRes.data.file_proxy.proxy_type).toBe("disk")
+  const getByIdData = await getByIdRes.json<any>()
+  expect(getByIdData.file_proxy.file_proxy_id).toBe(diskProxyId)
+  expect(getByIdData.file_proxy.proxy_type).toBe("disk")
 
-  // Get proxy by matching_pattern
-  const getByPatternRes = await axios.get("/file_proxies/get", {
-    params: { matching_pattern: "remote/*" },
+  const getByPatternRes = await ky.get("file_proxies/get", {
+    searchParams: { matching_pattern: "remote/*" },
   })
   expect(getByPatternRes.status).toBe(200)
-  expect(getByPatternRes.data.file_proxy.file_proxy_id).toBe(httpProxyId)
-  expect(getByPatternRes.data.file_proxy.proxy_type).toBe("http")
+  const getByPatternData = await getByPatternRes.json<any>()
+  expect(getByPatternData.file_proxy.file_proxy_id).toBe(httpProxyId)
+  expect(getByPatternData.file_proxy.proxy_type).toBe("http")
 
-  // Get non-existent proxy
-  const getNonExistentRes = await axios.get("/file_proxies/get", {
-    params: { file_proxy_id: "non-existent" },
+  const getNonExistentRes = await ky.get("file_proxies/get", {
+    searchParams: { file_proxy_id: "non-existent" },
   })
   expect(getNonExistentRes.status).toBe(200)
-  expect(getNonExistentRes.data.file_proxy).toBeNull()
+  const getNonExistentData = await getNonExistentRes.json<any>()
+  expect(getNonExistentData.file_proxy).toBeNull()
 
-  // List all proxies
-  const listRes = await axios.get("/file_proxies/list")
+  const listRes = await ky.get("file_proxies/list")
   expect(listRes.status).toBe(200)
-  expect(listRes.data.file_proxies).toHaveLength(2)
+  const listData = await listRes.json<any>()
+  expect(listData.file_proxies).toHaveLength(2)
 
-  const diskProxy = listRes.data.file_proxies.find(
-    (p: any) => p.proxy_type === "disk",
-  )
-  const httpProxy = listRes.data.file_proxies.find(
-    (p: any) => p.proxy_type === "http",
-  )
+  const diskProxy = listData.file_proxies.find((p: any) => p.proxy_type === "disk")
+  const httpProxy = listData.file_proxies.find((p: any) => p.proxy_type === "http")
   expect(diskProxy).toBeDefined()
   expect(httpProxy).toBeDefined()
 })
 
 test("file proxy create validation - duplicate pattern", async () => {
-  const { axios } = await getTestServer()
+  const { ky } = await getTestServer()
 
-  // Create first proxy
-  await axios.post("/file_proxies/create", {
-    proxy_type: "disk",
-    disk_path: "/tmp/test",
-    matching_pattern: "duplicate/*",
+  await ky.post("file_proxies/create", {
+    json: {
+      proxy_type: "disk",
+      disk_path: "/tmp/test",
+      matching_pattern: "duplicate/*",
+    },
   })
 
-  // Duplicate matching_pattern should fail with 400
-  await expect(
-    axios.post("/file_proxies/create", {
+  const duplicateRes = await ky.post("file_proxies/create", {
+    json: {
       proxy_type: "http",
       http_target_url: "https://example.com",
       matching_pattern: "duplicate/*",
-    }),
-  ).rejects.toMatchObject({
-    status: 400,
+    },
   })
+  expect(duplicateRes.status).toBe(400)
 })

--- a/tests/routes/file-proxy02.test.ts
+++ b/tests/routes/file-proxy02.test.ts
@@ -5,66 +5,53 @@ import { join } from "node:path"
 import { tmpdir } from "node:os"
 
 test("disk proxy file resolution", async () => {
-  const { axios } = await getTestServer()
+  const { ky } = await getTestServer()
 
-  // Create a temp directory with test files
   const tempDir = await mkdtemp(join(tmpdir(), "file-proxy-test-"))
 
   try {
-    // Create test files in the temp directory
     await writeFile(join(tempDir, "test.txt"), "Hello from disk proxy!")
     await writeFile(join(tempDir, "data.json"), '{"key": "value"}')
 
-    // Create a subdirectory with a file
     await mkdir(join(tempDir, "subdir"))
     await writeFile(
       join(tempDir, "subdir", "nested.txt"),
       "Nested file content",
     )
 
-    // Create a disk proxy pointing to the temp directory
-    const createRes = await axios.post("/file_proxies/create", {
-      proxy_type: "disk",
-      disk_path: tempDir,
-      matching_pattern: "disk-test/*",
+    const createRes = await ky.post("file_proxies/create", {
+      json: {
+        proxy_type: "disk",
+        disk_path: tempDir,
+        matching_pattern: "disk-test/*",
+      },
     })
     expect(createRes.status).toBe(200)
 
-    // Test downloading a file through the proxy
-    const downloadRes = await axios.get("/files/download/disk-test/test.txt")
+    const downloadRes = await ky.get("files/download/disk-test/test.txt")
     expect(downloadRes.status).toBe(200)
-    expect(downloadRes.data).toBe("Hello from disk proxy!")
+    expect(await downloadRes.text()).toBe("Hello from disk proxy!")
     expect(downloadRes.headers.get("content-type")).toBe("text/plain")
 
-    // Test downloading JSON file
-    const jsonRes = await axios.get("/files/download/disk-test/data.json")
+    const jsonRes = await ky.get("files/download/disk-test/data.json")
     expect(jsonRes.status).toBe(200)
-    expect(jsonRes.data).toEqual({ key: "value" })
+    expect(await jsonRes.json()).toEqual({ key: "value" })
     expect(jsonRes.headers.get("content-type")).toBe("application/json")
 
-    // Test downloading nested file
-    const nestedRes = await axios.get(
-      "/files/download/disk-test/subdir/nested.txt",
-    )
+    const nestedRes = await ky.get("files/download/disk-test/subdir/nested.txt")
     expect(nestedRes.status).toBe(200)
-    expect(nestedRes.data).toBe("Nested file content")
+    expect(await nestedRes.text()).toBe("Nested file content")
 
-    // Test 404 for non-existent file
-    await expect(
-      axios.get("/files/download/disk-test/non-existent.txt"),
-    ).rejects.toMatchObject({
-      status: 404,
-    })
+    const missingRes = await ky.get("files/download/disk-test/non-existent.txt")
+    expect(missingRes.status).toBe(404)
   } finally {
-    // Clean up temp directory
     await rm(tempDir, { recursive: true, force: true })
   }
 })
 
 test("disk proxy with query param download", async () => {
-  const { axios } = await getTestServer()
+  const { ky } = await getTestServer()
 
-  // Create a temp directory with a test file
   const tempDir = await mkdtemp(join(tmpdir(), "file-proxy-query-test-"))
 
   try {
@@ -73,50 +60,44 @@ test("disk proxy with query param download", async () => {
       "Query param download test",
     )
 
-    // Create a disk proxy
-    await axios.post("/file_proxies/create", {
-      proxy_type: "disk",
-      disk_path: tempDir,
-      matching_pattern: "query-disk/*",
+    await ky.post("file_proxies/create", {
+      json: {
+        proxy_type: "disk",
+        disk_path: tempDir,
+        matching_pattern: "query-disk/*",
+      },
     })
 
-    // Test downloading via query parameter
-    const downloadRes = await axios.get("/files/download", {
-      params: { file_path: "/query-disk/query-test.txt" },
+    const downloadRes = await ky.get("files/download", {
+      searchParams: { file_path: "/query-disk/query-test.txt" },
     })
     expect(downloadRes.status).toBe(200)
-    expect(downloadRes.data).toBe("Query param download test")
+    expect(await downloadRes.text()).toBe("Query param download test")
   } finally {
     await rm(tempDir, { recursive: true, force: true })
   }
 })
 
 test("disk proxy binary file", async () => {
-  const { axios } = await getTestServer()
+  const { ky } = await getTestServer()
 
   const tempDir = await mkdtemp(join(tmpdir(), "file-proxy-binary-test-"))
 
   try {
-    // Create a binary file
     const binaryData = new Uint8Array([0x00, 0x01, 0x02, 0xff, 0xfe, 0xfd])
     await writeFile(join(tempDir, "binary.bin"), binaryData)
 
-    // Create a disk proxy
-    await axios.post("/file_proxies/create", {
-      proxy_type: "disk",
-      disk_path: tempDir,
-      matching_pattern: "binary-test/*",
+    await ky.post("file_proxies/create", {
+      json: {
+        proxy_type: "disk",
+        disk_path: tempDir,
+        matching_pattern: "binary-test/*",
+      },
     })
 
-    // Test downloading binary file
-    const downloadRes = await axios.get(
-      "/files/download/binary-test/binary.bin",
-      {
-        responseType: "arrayBuffer",
-      },
-    )
+    const downloadRes = await ky.get("files/download/binary-test/binary.bin")
     expect(downloadRes.status).toBe(200)
-    expect(new Uint8Array(downloadRes.data)).toEqual(binaryData)
+    expect(new Uint8Array(await downloadRes.arrayBuffer())).toEqual(binaryData)
     expect(downloadRes.headers.get("content-type")).toBe(
       "application/octet-stream",
     )

--- a/tests/routes/file-proxy02.test.ts
+++ b/tests/routes/file-proxy02.test.ts
@@ -35,7 +35,7 @@ test("disk proxy file resolution", async () => {
 
     const jsonRes = await ky.get("files/download/disk-test/data.json")
     expect(jsonRes.status).toBe(200)
-    expect(await jsonRes.json()).toEqual({ key: "value" })
+    expect(await jsonRes.json<any>()).toEqual({ key: "value" })
     expect(jsonRes.headers.get("content-type")).toBe("application/json")
 
     const nestedRes = await ky.get("files/download/disk-test/subdir/nested.txt")

--- a/tests/routes/file-proxy03.test.ts
+++ b/tests/routes/file-proxy03.test.ts
@@ -3,105 +3,104 @@ import { getTestServer } from "tests/fixtures/get-test-server"
 import { Buffer } from "node:buffer"
 
 test("http proxy file resolution", async () => {
-  const { axios, url } = await getTestServer()
+  const { ky, url } = await getTestServer()
 
-  // First, create a file on the server that we'll proxy to
-  await axios.post("/files/upsert", {
-    file_path: "/source/test-file.txt",
-    text_content: "Content served via HTTP proxy",
+  await ky.post("files/upsert", {
+    json: {
+      file_path: "/source/test-file.txt",
+      text_content: "Content served via HTTP proxy",
+    },
   })
 
-  await axios.post("/files/upsert", {
-    file_path: "/source/data.json",
-    text_content: '{"proxied": true}',
+  await ky.post("files/upsert", {
+    json: {
+      file_path: "/source/data.json",
+      text_content: '{"proxied": true}',
+    },
   })
 
-  // Create an HTTP proxy pointing to the server's static file endpoint
-  const createRes = await axios.post("/file_proxies/create", {
-    proxy_type: "http",
-    http_target_url: `${url}/files/static/source`,
-    matching_pattern: "http-test/*",
+  const createRes = await ky.post("file_proxies/create", {
+    json: {
+      proxy_type: "http",
+      http_target_url: `${url}/files/static/source`,
+      matching_pattern: "http-test/*",
+    },
   })
   expect(createRes.status).toBe(200)
-  expect(createRes.data.file_proxy.proxy_type).toBe("http")
+  expect((await createRes.json<any>()).file_proxy.proxy_type).toBe("http")
 
-  // Test downloading a file through the HTTP proxy
-  const downloadRes = await axios.get("/files/download/http-test/test-file.txt")
+  const downloadRes = await ky.get("files/download/http-test/test-file.txt")
   expect(downloadRes.status).toBe(200)
-  expect(downloadRes.data).toBe("Content served via HTTP proxy")
+  expect(await downloadRes.text()).toBe("Content served via HTTP proxy")
 
-  // Test downloading JSON through proxy
-  const jsonRes = await axios.get("/files/download/http-test/data.json")
+  const jsonRes = await ky.get("files/download/http-test/data.json")
   expect(jsonRes.status).toBe(200)
-  expect(jsonRes.data).toEqual({ proxied: true })
+  expect(await jsonRes.json()).toEqual({ proxied: true })
 })
 
 test("http proxy 404 handling", async () => {
-  const { axios, url } = await getTestServer()
+  const { ky, url } = await getTestServer()
 
-  // Create an HTTP proxy pointing to the server
-  await axios.post("/file_proxies/create", {
-    proxy_type: "http",
-    http_target_url: `${url}/files/static/nonexistent`,
-    matching_pattern: "http-404/*",
+  await ky.post("file_proxies/create", {
+    json: {
+      proxy_type: "http",
+      http_target_url: `${url}/files/static/nonexistent`,
+      matching_pattern: "http-404/*",
+    },
   })
 
-  // Test that 404 is properly propagated
-  await expect(
-    axios.get("/files/download/http-404/missing.txt"),
-  ).rejects.toMatchObject({
-    status: 404,
-  })
+  const missingRes = await ky.get("files/download/http-404/missing.txt")
+  expect(missingRes.status).toBe(404)
 })
 
 test("http proxy with query param download", async () => {
-  const { axios, url } = await getTestServer()
+  const { ky, url } = await getTestServer()
 
-  // Create source file
-  await axios.post("/files/upsert", {
-    file_path: "/query-source/file.txt",
-    text_content: "Query param HTTP proxy test",
+  await ky.post("files/upsert", {
+    json: {
+      file_path: "/query-source/file.txt",
+      text_content: "Query param HTTP proxy test",
+    },
   })
 
-  // Create HTTP proxy
-  await axios.post("/file_proxies/create", {
-    proxy_type: "http",
-    http_target_url: `${url}/files/static/query-source`,
-    matching_pattern: "http-query/*",
+  await ky.post("file_proxies/create", {
+    json: {
+      proxy_type: "http",
+      http_target_url: `${url}/files/static/query-source`,
+      matching_pattern: "http-query/*",
+    },
   })
 
-  // Test downloading via query parameter
-  const downloadRes = await axios.get("/files/download", {
-    params: { file_path: "/http-query/file.txt" },
+  const downloadRes = await ky.get("files/download", {
+    searchParams: { file_path: "/http-query/file.txt" },
   })
   expect(downloadRes.status).toBe(200)
-  expect(downloadRes.data).toBe("Query param HTTP proxy test")
+  expect(await downloadRes.text()).toBe("Query param HTTP proxy test")
 })
 
 test("http proxy binary file", async () => {
-  const { axios, url } = await getTestServer()
+  const { ky, url } = await getTestServer()
 
-  // Create a binary file on the server
   const binaryData = new Uint8Array([
     0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
   ])
   const base64 = Buffer.from(binaryData).toString("base64")
-  await axios.post("/files/upsert", {
-    file_path: "/binary-source/image.png",
-    binary_content_b64: base64,
+  await ky.post("files/upsert", {
+    json: {
+      file_path: "/binary-source/image.png",
+      binary_content_b64: base64,
+    },
   })
 
-  // Create HTTP proxy
-  await axios.post("/file_proxies/create", {
-    proxy_type: "http",
-    http_target_url: `${url}/files/static/binary-source`,
-    matching_pattern: "http-binary/*",
+  await ky.post("file_proxies/create", {
+    json: {
+      proxy_type: "http",
+      http_target_url: `${url}/files/static/binary-source`,
+      matching_pattern: "http-binary/*",
+    },
   })
 
-  // Test downloading binary file through proxy
-  const downloadRes = await axios.get("/files/download/http-binary/image.png", {
-    responseType: "arrayBuffer",
-  })
+  const downloadRes = await ky.get("files/download/http-binary/image.png")
   expect(downloadRes.status).toBe(200)
-  expect(new Uint8Array(downloadRes.data)).toEqual(binaryData)
+  expect(new Uint8Array(await downloadRes.arrayBuffer())).toEqual(binaryData)
 })

--- a/tests/routes/file-proxy03.test.ts
+++ b/tests/routes/file-proxy03.test.ts
@@ -35,7 +35,7 @@ test("http proxy file resolution", async () => {
 
   const jsonRes = await ky.get("files/download/http-test/data.json")
   expect(jsonRes.status).toBe(200)
-  expect(await jsonRes.json()).toEqual({ proxied: true })
+  expect(await jsonRes.json<any>()).toEqual({ proxied: true })
 })
 
 test("http proxy 404 handling", async () => {

--- a/tests/routes/file-proxy04.test.ts
+++ b/tests/routes/file-proxy04.test.ts
@@ -5,43 +5,42 @@ import { join } from "node:path"
 import { tmpdir } from "node:os"
 
 test("database file takes precedence over proxy", async () => {
-  const { axios } = await getTestServer()
+  const { ky } = await getTestServer()
 
   const tempDir = await mkdtemp(join(tmpdir(), "file-proxy-precedence-"))
 
   try {
-    // Create a file on disk
     await writeFile(join(tempDir, "test.txt"), "Disk content")
 
-    // Create a disk proxy
-    await axios.post("/file_proxies/create", {
-      proxy_type: "disk",
-      disk_path: tempDir,
-      matching_pattern: "precedence/*",
+    await ky.post("file_proxies/create", {
+      json: {
+        proxy_type: "disk",
+        disk_path: tempDir,
+        matching_pattern: "precedence/*",
+      },
     })
 
-    // Create a file in the database with the same path
-    await axios.post("/files/upsert", {
-      file_path: "/precedence/test.txt",
-      text_content: "Database content",
+    await ky.post("files/upsert", {
+      json: {
+        file_path: "/precedence/test.txt",
+        text_content: "Database content",
+      },
     })
 
-    // Database file should take precedence
-    const downloadRes = await axios.get("/files/download/precedence/test.txt")
+    const downloadRes = await ky.get("files/download/precedence/test.txt")
     expect(downloadRes.status).toBe(200)
-    expect(downloadRes.data).toBe("Database content")
+    expect(await downloadRes.text()).toBe("Database content")
   } finally {
     await rm(tempDir, { recursive: true, force: true })
   }
 })
 
 test("proxy pattern matching with deep paths", async () => {
-  const { axios } = await getTestServer()
+  const { ky } = await getTestServer()
 
   const tempDir = await mkdtemp(join(tmpdir(), "file-proxy-deep-"))
 
   try {
-    // Create deeply nested file
     const { mkdir } = await import("node:fs/promises")
     await mkdir(join(tempDir, "a", "b", "c"), { recursive: true })
     await writeFile(
@@ -49,65 +48,59 @@ test("proxy pattern matching with deep paths", async () => {
       "Deep nested content",
     )
 
-    // Create a disk proxy
-    await axios.post("/file_proxies/create", {
-      proxy_type: "disk",
-      disk_path: tempDir,
-      matching_pattern: "deep/*",
+    await ky.post("file_proxies/create", {
+      json: {
+        proxy_type: "disk",
+        disk_path: tempDir,
+        matching_pattern: "deep/*",
+      },
     })
 
-    // Test downloading deeply nested file
-    const downloadRes = await axios.get("/files/download/deep/a/b/c/deep.txt")
+    const downloadRes = await ky.get("files/download/deep/a/b/c/deep.txt")
     expect(downloadRes.status).toBe(200)
-    expect(downloadRes.data).toBe("Deep nested content")
+    expect(await downloadRes.text()).toBe("Deep nested content")
   } finally {
     await rm(tempDir, { recursive: true, force: true })
   }
 })
 
 test("multiple proxies with different patterns", async () => {
-  const { axios } = await getTestServer()
+  const { ky } = await getTestServer()
 
   const tempDir1 = await mkdtemp(join(tmpdir(), "file-proxy-multi1-"))
   const tempDir2 = await mkdtemp(join(tmpdir(), "file-proxy-multi2-"))
 
   try {
-    // Create files in different directories
     await writeFile(join(tempDir1, "file1.txt"), "Content from dir 1")
     await writeFile(join(tempDir2, "file2.txt"), "Content from dir 2")
 
-    // Create two different proxies
-    await axios.post("/file_proxies/create", {
-      proxy_type: "disk",
-      disk_path: tempDir1,
-      matching_pattern: "multi1/*",
+    await ky.post("file_proxies/create", {
+      json: {
+        proxy_type: "disk",
+        disk_path: tempDir1,
+        matching_pattern: "multi1/*",
+      },
     })
 
-    await axios.post("/file_proxies/create", {
-      proxy_type: "disk",
-      disk_path: tempDir2,
-      matching_pattern: "multi2/*",
+    await ky.post("file_proxies/create", {
+      json: {
+        proxy_type: "disk",
+        disk_path: tempDir2,
+        matching_pattern: "multi2/*",
+      },
     })
 
-    // Test that each proxy serves its own files
-    const res1 = await axios.get("/files/download/multi1/file1.txt")
-    expect(res1.data).toBe("Content from dir 1")
+    const res1 = await ky.get("files/download/multi1/file1.txt")
+    expect(await res1.text()).toBe("Content from dir 1")
 
-    const res2 = await axios.get("/files/download/multi2/file2.txt")
-    expect(res2.data).toBe("Content from dir 2")
+    const res2 = await ky.get("files/download/multi2/file2.txt")
+    expect(await res2.text()).toBe("Content from dir 2")
 
-    // Test that proxies don't cross
-    await expect(
-      axios.get("/files/download/multi1/file2.txt"),
-    ).rejects.toMatchObject({
-      status: 404,
-    })
+    const missing1 = await ky.get("files/download/multi1/file2.txt")
+    expect(missing1.status).toBe(404)
 
-    await expect(
-      axios.get("/files/download/multi2/file1.txt"),
-    ).rejects.toMatchObject({
-      status: 404,
-    })
+    const missing2 = await ky.get("files/download/multi2/file1.txt")
+    expect(missing2.status).toBe(404)
   } finally {
     await rm(tempDir1, { recursive: true, force: true })
     await rm(tempDir2, { recursive: true, force: true })
@@ -115,51 +108,48 @@ test("multiple proxies with different patterns", async () => {
 })
 
 test("no proxy match returns 404", async () => {
-  const { axios } = await getTestServer()
+  const { ky } = await getTestServer()
 
-  // Create a proxy with a specific pattern
   const tempDir = await mkdtemp(join(tmpdir(), "file-proxy-nomatch-"))
 
   try {
     await writeFile(join(tempDir, "exists.txt"), "File exists")
 
-    await axios.post("/file_proxies/create", {
-      proxy_type: "disk",
-      disk_path: tempDir,
-      matching_pattern: "specific/*",
+    await ky.post("file_proxies/create", {
+      json: {
+        proxy_type: "disk",
+        disk_path: tempDir,
+        matching_pattern: "specific/*",
+      },
     })
 
-    // Path that doesn't match any proxy pattern should 404
-    await expect(
-      axios.get("/files/download/unmatched/file.txt"),
-    ).rejects.toMatchObject({
-      status: 404,
-      data: "File not found",
-    })
+    const missingRes = await ky.get("files/download/unmatched/file.txt")
+    expect(missingRes.status).toBe(404)
+    expect(await missingRes.text()).toBe("File not found")
   } finally {
     await rm(tempDir, { recursive: true, force: true })
   }
 })
 
 test("proxy pattern with leading slash normalization", async () => {
-  const { axios } = await getTestServer()
+  const { ky } = await getTestServer()
 
   const tempDir = await mkdtemp(join(tmpdir(), "file-proxy-slash-"))
 
   try {
     await writeFile(join(tempDir, "normalized.txt"), "Normalized path content")
 
-    // Create proxy with pattern (without leading slash in pattern)
-    await axios.post("/file_proxies/create", {
-      proxy_type: "disk",
-      disk_path: tempDir,
-      matching_pattern: "slash-test/*",
+    await ky.post("file_proxies/create", {
+      json: {
+        proxy_type: "disk",
+        disk_path: tempDir,
+        matching_pattern: "slash-test/*",
+      },
     })
 
-    // Should work with leading slash in the request path
-    const res = await axios.get("/files/download/slash-test/normalized.txt")
+    const res = await ky.get("files/download/slash-test/normalized.txt")
     expect(res.status).toBe(200)
-    expect(res.data).toBe("Normalized path content")
+    expect(await res.text()).toBe("Normalized path content")
   } finally {
     await rm(tempDir, { recursive: true, force: true })
   }

--- a/tests/routes/files.test.ts
+++ b/tests/routes/files.test.ts
@@ -3,57 +3,64 @@ import { getTestServer } from "tests/fixtures/get-test-server"
 import { Buffer } from "node:buffer"
 
 test("file operations", async () => {
-  const { axios } = await getTestServer()
+  const { ky } = await getTestServer()
 
-  // Create a file
-  const createRes = await axios.post("/files/upsert", {
-    file_path: "/test.txt",
-    text_content: "Hello World",
-  })
-  expect(createRes.data.file.file_path).toBe("test.txt")
-  expect(createRes.data.file.text_content).toBe("Hello World")
+  const createData = await ky
+    .post("files/upsert", {
+      json: {
+        file_path: "/test.txt",
+        text_content: "Hello World",
+      },
+    })
+    .json<{ file: { file_path: string; text_content: string } }>()
+  expect(createData.file.file_path).toBe("test.txt")
+  expect(createData.file.text_content).toBe("Hello World")
 
-  // Get the file
-  const getRes = await axios.get("/files/get", {
-    params: { file_path: "/test.txt" },
-  })
-  expect(getRes.data.file.text_content).toBe("Hello World")
+  const getData = await ky
+    .get("files/get", {
+      searchParams: { file_path: "/test.txt" },
+    })
+    .json<{ file: { text_content: string } }>()
+  expect(getData.file.text_content).toBe("Hello World")
 
-  // List files
-  const listRes = await axios.get("/files/list")
-  expect(listRes.data.file_list).toHaveLength(1)
-  expect(listRes.data.file_list[0].file_path).toBe("test.txt")
+  const listData = await ky.get("files/list").json<{ file_list: any[] }>()
+  expect(listData.file_list).toHaveLength(1)
+  expect(listData.file_list[0].file_path).toBe("test.txt")
 
-  // Check events
-  const eventsRes = await axios.get("/events/list")
-  expect(eventsRes.data.event_list).toHaveLength(1)
-  expect(eventsRes.data.event_list[0].event_type).toBe("FILE_UPDATED")
-  expect(eventsRes.data.event_list[0].file_path).toBe("test.txt")
+  const eventsData = await ky.get("events/list").json<{ event_list: any[] }>()
+  expect(eventsData.event_list).toHaveLength(1)
+  expect(eventsData.event_list[0].event_type).toBe("FILE_UPDATED")
+  expect(eventsData.event_list[0].file_path).toBe("test.txt")
 })
 
 test("binary file operations", async () => {
-  const { axios } = await getTestServer()
+  const { ky } = await getTestServer()
 
   const buffer = Buffer.from([0, 1, 2, 3, 128, 255, 200])
   const base64 = buffer.toString("base64")
 
-  const createRes = await axios.post("/files/upsert", {
-    file_path: "/bin.dat",
-    binary_content_b64: base64,
-  })
-  expect(createRes.data.file.binary_content_b64).toBe(base64)
+  const createData = await ky
+    .post("files/upsert", {
+      json: {
+        file_path: "/bin.dat",
+        binary_content_b64: base64,
+      },
+    })
+    .json<{ file: { binary_content_b64: string } }>()
+  expect(createData.file.binary_content_b64).toBe(base64)
 
-  const getRes = await axios.get("/files/get", {
-    params: { file_path: "/bin.dat" },
-  })
-  expect(getRes.data.file.binary_content_b64).toBe(base64)
+  const getData = await ky
+    .get("files/get", {
+      searchParams: { file_path: "/bin.dat" },
+    })
+    .json<{ file: { binary_content_b64: string } }>()
+  expect(getData.file.binary_content_b64).toBe(base64)
 
-  const downloadRes = await axios.get("/files/download", {
-    params: { file_path: "/bin.dat" },
-    responseType: "arrayBuffer",
+  const downloadRes = await ky.get("files/download", {
+    searchParams: { file_path: "/bin.dat" },
   })
   expect(downloadRes.status).toBe(200)
-  expect(Buffer.from(downloadRes.data)).toEqual(buffer)
+  expect(Buffer.from(await downloadRes.arrayBuffer())).toEqual(buffer)
   expect(downloadRes.headers.get("content-type")).toBe(
     "application/octet-stream",
   )
@@ -63,209 +70,221 @@ test("binary file operations", async () => {
 })
 
 test("file download operations", async () => {
-  const { axios } = await getTestServer()
+  const { ky } = await getTestServer()
 
-  await axios.post("/files/upsert", {
-    file_path: "/download-test.txt",
-    text_content: "Test download content",
+  await ky.post("files/upsert", {
+    json: {
+      file_path: "/download-test.txt",
+      text_content: "Test download content",
+    },
   })
 
-  const successRes = await axios.get("/files/download", {
-    params: { file_path: "/download-test.txt" },
+  const successRes = await ky.get("files/download", {
+    searchParams: { file_path: "/download-test.txt" },
   })
   expect(successRes.status).toBe(200)
-  expect(successRes.data).toBe("Test download content")
+  expect(await successRes.text()).toBe("Test download content")
   expect(successRes.headers.get("content-type")).toBe("text/plain")
   expect(successRes.headers.get("content-disposition")).toBe(
     'attachment; filename="download-test.txt"',
   )
 
-  expect(
-    axios.get("/files/download", {
-      params: { file_path: "/missing-file.txt" },
-    }),
-  ).rejects.toMatchObject({
-    status: 404,
-    data: "File not found",
+  const missingRes = await ky.get("files/download", {
+    searchParams: { file_path: "/missing-file.txt" },
   })
+  expect(missingRes.status).toBe(404)
+  expect(await missingRes.text()).toBe("File not found")
 })
 
-test("file download operations2", async () => {
-  const { axios } = await getTestServer()
+test("file path download operations", async () => {
+  const { ky } = await getTestServer()
 
-  await axios.post("/files/upsert", {
-    file_path: "/download-test2.txt",
-    text_content: "Test download content",
+  await ky.post("files/upsert", {
+    json: {
+      file_path: "/download-test2.txt",
+      text_content: "Test download content",
+    },
   })
 
-  const successRes = await axios.get("/files/download/download-test2.txt")
+  const successRes = await ky.get("files/download/download-test2.txt")
   expect(successRes.status).toBe(200)
-  expect(successRes.data).toBe("Test download content")
+  expect(await successRes.text()).toBe("Test download content")
   expect(successRes.headers.get("content-type")).toBe("text/plain")
   expect(successRes.headers.get("content-disposition")).toBe(
     'attachment; filename="download-test2.txt"',
   )
 
-  expect(axios.get("/files/download/missing-file.txt")).rejects.toMatchObject({
-    status: 404,
-    data: "File not found",
-  })
+  const missingRes = await ky.get("files/download/missing-file.txt")
+  expect(missingRes.status).toBe(404)
+  expect(await missingRes.text()).toBe("File not found")
 })
 
 test("file delete operations", async () => {
-  const { axios } = await getTestServer()
+  const { ky } = await getTestServer()
 
-  const createResPath = await axios.post("/files/upsert", {
-    file_path: "/delete-by-path.txt",
-    text_content: "Delete me by path",
-  })
-  const filePathToDelete = createResPath.data.file.file_path
+  const createByPathData = await ky
+    .post("files/upsert", {
+      json: {
+        file_path: "/delete-by-path.txt",
+        text_content: "Delete me by path",
+      },
+    })
+    .json<{ file: { file_path: string } }>()
+  const filePathToDelete = createByPathData.file.file_path
 
-  const deleteResPath = await axios.post("/files/delete", {
-    file_path: filePathToDelete,
-    initiator: "test-path-delete",
+  const deleteResPath = await ky.post("files/delete", {
+    json: {
+      file_path: filePathToDelete,
+      initiator: "test-path-delete",
+    },
   })
   expect(deleteResPath.status).toBe(204)
 
-  let listRes = await axios.get("/files/list")
+  let listData = await ky.get("files/list").json<{ file_list: any[] }>()
   expect(
-    listRes.data.file_list.find((f: any) => f.file_path === filePathToDelete),
+    listData.file_list.find((f: any) => f.file_path === filePathToDelete),
   ).toBeUndefined()
 
-  let eventsRes = await axios.get("/events/list")
-  const deleteEventPath = eventsRes.data.event_list.find(
+  let eventsData = await ky.get("events/list").json<{ event_list: any[] }>()
+  const deleteEventPath = eventsData.event_list.find(
     (e: any) =>
       e.event_type === "FILE_DELETED" && e.file_path === filePathToDelete,
   )
   expect(deleteEventPath).toBeDefined()
   expect(deleteEventPath.initiator).toBe("test-path-delete")
 
-  const createResId = await axios.post("/files/upsert", {
-    file_path: "/delete-by-id.txt",
-    text_content: "Delete me by id",
-  })
-  const fileIdToDelete = createResId.data.file.file_id
-  const filePathById = createResId.data.file.file_path
+  const createByIdData = await ky
+    .post("files/upsert", {
+      json: {
+        file_path: "/delete-by-id.txt",
+        text_content: "Delete me by id",
+      },
+    })
+    .json<{ file: { file_id: string; file_path: string } }>()
+  const fileIdToDelete = createByIdData.file.file_id
+  const filePathById = createByIdData.file.file_path
 
-  const deleteResId = await axios.post("/files/delete", {
-    file_id: fileIdToDelete,
+  const deleteResId = await ky.post("files/delete", {
+    json: {
+      file_id: fileIdToDelete,
+    },
   })
   expect(deleteResId.status).toBe(204)
 
-  listRes = await axios.get("/files/list")
+  listData = await ky.get("files/list").json<{ file_list: any[] }>()
   expect(
-    listRes.data.file_list.find((f: any) => f.file_id === fileIdToDelete),
+    listData.file_list.find((f: any) => f.file_id === fileIdToDelete),
   ).toBeUndefined()
 
-  eventsRes = await axios.get("/events/list")
-  const deleteEventId = eventsRes.data.event_list.find(
+  eventsData = await ky.get("events/list").json<{ event_list: any[] }>()
+  const deleteEventId = eventsData.event_list.find(
     (e: any) => e.event_type === "FILE_DELETED" && e.file_path === filePathById,
   )
   expect(deleteEventId).toBeDefined()
   expect(deleteEventId.file_path).toBe(filePathById)
 
-  expect(
-    axios.delete("/files/delete", {
-      data: {
-        file_path: "/non-existent-path.txt",
-      },
-    }),
-  ).rejects.toMatchObject({
-    status: 404,
-    data: { error: "File not found" },
+  const missingPathRes = await ky.delete("files/delete", {
+    json: {
+      file_path: "/non-existent-path.txt",
+    },
   })
+  expect(missingPathRes.status).toBe(404)
+  expect(await missingPathRes.json()).toEqual({ error: "File not found" })
 
-  expect(
-    axios.post("/files/delete", {
+  const missingIdRes = await ky.post("files/delete", {
+    json: {
       file_id: "non-existent-id",
-    }),
-  ).rejects.toMatchObject({
-    status: 404,
-    data: { error: "File not found" },
+    },
   })
+  expect(missingIdRes.status).toBe(404)
+  expect(await missingIdRes.json()).toEqual({ error: "File not found" })
 
-  expect(axios.delete("/files/delete", { data: {} })).rejects.toMatchObject({
-    status: 400,
-  })
+  const badDeleteRes = await ky.delete("files/delete", { json: {} })
+  expect(badDeleteRes.status).toBe(400)
 })
 
 test("file rename operations", async () => {
-  const { axios } = await getTestServer()
+  const { ky } = await getTestServer()
 
-  const createRes = await axios.post("/files/upsert", {
-    file_path: "/original.txt",
-    text_content: "Original content",
-  })
-  const originalFile = createRes.data.file
+  const createData = await ky
+    .post("files/upsert", {
+      json: {
+        file_path: "/original.txt",
+        text_content: "Original content",
+      },
+    })
+    .json<{ file: { file_id: string } }>()
+  const originalFile = createData.file
 
-  const renameRes = await axios.post("/files/rename", {
-    old_file_path: "/original.txt",
-    new_file_path: "/renamed.txt",
-    initiator: "test-rename",
+  const renameRes = await ky.post("files/rename", {
+    json: {
+      old_file_path: "/original.txt",
+      new_file_path: "/renamed.txt",
+      initiator: "test-rename",
+    },
   })
   expect(renameRes.status).toBe(200)
-  expect(renameRes.data.file.file_path).toBe("renamed.txt")
-  expect(renameRes.data.file.text_content).toBe("Original content")
-  expect(renameRes.data.file.file_id).toBe(originalFile.file_id)
+  const renameData = await renameRes.json<any>()
+  expect(renameData.file.file_path).toBe("renamed.txt")
+  expect(renameData.file.text_content).toBe("Original content")
+  expect(renameData.file.file_id).toBe(originalFile.file_id)
 
-  const getOldRes = await axios.get("/files/get", {
-    params: { file_path: "/original.txt" },
-  })
-  expect(getOldRes.data.file).toBeNull()
+  const getOldData = await ky
+    .get("files/get", {
+      searchParams: { file_path: "/original.txt" },
+    })
+    .json<{ file: null }>()
+  expect(getOldData.file).toBeNull()
 
-  const getNewRes = await axios.get("/files/get", {
-    params: { file_path: "/renamed.txt" },
-  })
-  expect(getNewRes.data.file.text_content).toBe("Original content")
+  const getNewData = await ky
+    .get("files/get", {
+      searchParams: { file_path: "/renamed.txt" },
+    })
+    .json<{ file: { text_content: string } }>()
+  expect(getNewData.file.text_content).toBe("Original content")
 
-  const eventsRes = await axios.get("/events/list")
-  const createdEvent = eventsRes.data.event_list.find(
-    (e: any) =>
-      e.event_type === "FILE_CREATED" && e.file_path === "renamed.txt",
+  const eventsData = await ky.get("events/list").json<{ event_list: any[] }>()
+  const createdEvent = eventsData.event_list.find(
+    (e: any) => e.event_type === "FILE_CREATED" && e.file_path === "renamed.txt",
   )
   expect(createdEvent).toBeDefined()
   expect(createdEvent.initiator).toBe("test-rename")
 
-  const deletedEvent = eventsRes.data.event_list.find(
-    (e: any) =>
-      e.event_type === "FILE_DELETED" && e.file_path === "original.txt",
+  const deletedEvent = eventsData.event_list.find(
+    (e: any) => e.event_type === "FILE_DELETED" && e.file_path === "original.txt",
   )
   expect(deletedEvent).toBeDefined()
   expect(deletedEvent.initiator).toBe("test-rename")
 
-  // Test error cases
-  // Try to rename non-existent file
-  await expect(
-    axios.post("/files/rename", {
+  const missingRenameRes = await ky.post("files/rename", {
+    json: {
       old_file_path: "/non-existent.txt",
       new_file_path: "/new.txt",
-    }),
-  ).rejects.toMatchObject({
-    status: 404,
-    data: { file: null },
+    },
+  })
+  expect(missingRenameRes.status).toBe(404)
+  expect(await missingRenameRes.json()).toEqual({ file: null })
+
+  await ky.post("files/upsert", {
+    json: {
+      file_path: "/existing.txt",
+      text_content: "Existing file",
+    },
   })
 
-  // Try to rename to existing file
-  await axios.post("/files/upsert", {
-    file_path: "/existing.txt",
-    text_content: "Existing file",
-  })
-
-  await expect(
-    axios.post("/files/rename", {
+  const conflictRenameRes = await ky.post("files/rename", {
+    json: {
       old_file_path: "/renamed.txt",
       new_file_path: "/existing.txt",
-    }),
-  ).rejects.toMatchObject({
-    status: 409,
-    data: { file: null },
+    },
   })
+  expect(conflictRenameRes.status).toBe(409)
+  expect(await conflictRenameRes.json()).toEqual({ file: null })
 })
 
 test("file static serving operations", async () => {
-  const { axios, url } = await getTestServer()
+  const { ky, url } = await getTestServer()
 
-  // Test different file types with their MIME types
   const testFiles: Array<{
     path: string
     expectedMime: string
@@ -315,30 +334,9 @@ test("file static serving operations", async () => {
     {
       path: "/models/test.glb",
       binaryContent: Buffer.from([
-        0x67,
-        0x6c,
-        0x54,
-        0x46, // "glTF" magic
-        0x02,
-        0x00,
-        0x00,
-        0x00, // version 2
-        0x1c,
-        0x00,
-        0x00,
-        0x00, // total length
-        0x4e,
-        0x4f,
-        0x44,
-        0x45, // chunk type "NODE"
-        0x00,
-        0x00,
-        0x00,
-        0x00, // placeholder chunk data
-        0x80,
-        0xff,
-        0xfe,
-        0xfd, // bytes with high bits set
+        0x67, 0x6c, 0x54, 0x46, 0x02, 0x00, 0x00, 0x00, 0x1c, 0x00, 0x00,
+        0x00, 0x4e, 0x4f, 0x44, 0x45, 0x00, 0x00, 0x00, 0x00, 0x80, 0xff,
+        0xfe, 0xfd,
       ]),
       expectedMime: "model/gltf-binary",
     },
@@ -346,14 +344,18 @@ test("file static serving operations", async () => {
 
   for (const file of testFiles) {
     if (file.binaryContent) {
-      await axios.post("/files/upsert", {
-        file_path: file.path,
-        binary_content_b64: file.binaryContent.toString("base64"),
+      await ky.post("files/upsert", {
+        json: {
+          file_path: file.path,
+          binary_content_b64: file.binaryContent.toString("base64"),
+        },
       })
     } else {
-      await axios.post("/files/upsert", {
-        file_path: file.path,
-        text_content: file.content,
+      await ky.post("files/upsert", {
+        json: {
+          file_path: file.path,
+          text_content: file.content,
+        },
       })
     }
 
@@ -365,7 +367,6 @@ test("file static serving operations", async () => {
       const expectedBytes = new Uint8Array(file.binaryContent)
       expect(Array.from(responseBytes)).toEqual(Array.from(expectedBytes))
       expect(response.headers.get("content-type")).toBe(file.expectedMime)
-      // Should NOT have attachment disposition (unlike download route)
       expect(response.headers.get("content-disposition")).toBeNull()
       expect(response.headers.get("content-length")).toBe(
         file.binaryContent.byteLength.toString(),
@@ -373,25 +374,20 @@ test("file static serving operations", async () => {
       continue
     }
 
-    const response = await axios.get(`/files/static${file.path}`)
-
+    const response = await ky.get(`files/static${file.path}`)
     expect(response.status).toBe(200)
 
     if (file.expectedMime === "application/json") {
-      // For JSON files, axios parses the response, so compare the parsed object
-      expect(response.data).toEqual(JSON.parse(file.content!))
+      expect(await response.json()).toEqual(JSON.parse(file.content!))
     } else {
-      expect(response.data).toBe(file.content)
+      expect(await response.text()).toBe(file.content)
     }
 
     expect(response.headers.get("content-type")).toBe(file.expectedMime)
-    // Should NOT have attachment disposition (unlike download route)
     expect(response.headers.get("content-disposition")).toBeNull()
   }
 
-  // Test 404 for missing file
-  expect(axios.get("/files/static/missing-file.txt")).rejects.toMatchObject({
-    status: 404,
-    data: "File not found",
-  })
+  const missingRes = await ky.get("files/static/missing-file.txt")
+  expect(missingRes.status).toBe(404)
+  expect(await missingRes.text()).toBe("File not found")
 })

--- a/tests/routes/files.test.ts
+++ b/tests/routes/files.test.ts
@@ -189,7 +189,7 @@ test("file delete operations", async () => {
     },
   })
   expect(missingPathRes.status).toBe(404)
-  expect(await missingPathRes.json()).toEqual({ error: "File not found" })
+  expect(await missingPathRes.json<any>()).toEqual({ error: "File not found" })
 
   const missingIdRes = await ky.post("files/delete", {
     json: {
@@ -197,7 +197,7 @@ test("file delete operations", async () => {
     },
   })
   expect(missingIdRes.status).toBe(404)
-  expect(await missingIdRes.json()).toEqual({ error: "File not found" })
+  expect(await missingIdRes.json<any>()).toEqual({ error: "File not found" })
 
   const badDeleteRes = await ky.delete("files/delete", { json: {} })
   expect(badDeleteRes.status).toBe(400)
@@ -263,7 +263,7 @@ test("file rename operations", async () => {
     },
   })
   expect(missingRenameRes.status).toBe(404)
-  expect(await missingRenameRes.json()).toEqual({ file: null })
+  expect(await missingRenameRes.json<any>()).toEqual({ file: null })
 
   await ky.post("files/upsert", {
     json: {
@@ -279,7 +279,7 @@ test("file rename operations", async () => {
     },
   })
   expect(conflictRenameRes.status).toBe(409)
-  expect(await conflictRenameRes.json()).toEqual({ file: null })
+  expect(await conflictRenameRes.json<any>()).toEqual({ file: null })
 })
 
 test("file static serving operations", async () => {
@@ -378,9 +378,9 @@ test("file static serving operations", async () => {
     expect(response.status).toBe(200)
 
     if (file.expectedMime === "application/json") {
-      expect(await response.json()).toEqual(JSON.parse(file.content!))
+      expect(await response.json<any>()).toEqual(JSON.parse(file.content!))
     } else {
-      expect(await response.text()).toBe(file.content)
+      expect(await response.text()).toBe(file.content!)
     }
 
     expect(response.headers.get("content-type")).toBe(file.expectedMime)

--- a/tests/routes/files.test.ts
+++ b/tests/routes/files.test.ts
@@ -245,13 +245,15 @@ test("file rename operations", async () => {
 
   const eventsData = await ky.get("events/list").json<{ event_list: any[] }>()
   const createdEvent = eventsData.event_list.find(
-    (e: any) => e.event_type === "FILE_CREATED" && e.file_path === "renamed.txt",
+    (e: any) =>
+      e.event_type === "FILE_CREATED" && e.file_path === "renamed.txt",
   )
   expect(createdEvent).toBeDefined()
   expect(createdEvent.initiator).toBe("test-rename")
 
   const deletedEvent = eventsData.event_list.find(
-    (e: any) => e.event_type === "FILE_DELETED" && e.file_path === "original.txt",
+    (e: any) =>
+      e.event_type === "FILE_DELETED" && e.file_path === "original.txt",
   )
   expect(deletedEvent).toBeDefined()
   expect(deletedEvent.initiator).toBe("test-rename")
@@ -334,9 +336,8 @@ test("file static serving operations", async () => {
     {
       path: "/models/test.glb",
       binaryContent: Buffer.from([
-        0x67, 0x6c, 0x54, 0x46, 0x02, 0x00, 0x00, 0x00, 0x1c, 0x00, 0x00,
-        0x00, 0x4e, 0x4f, 0x44, 0x45, 0x00, 0x00, 0x00, 0x00, 0x80, 0xff,
-        0xfe, 0xfd,
+        0x67, 0x6c, 0x54, 0x46, 0x02, 0x00, 0x00, 0x00, 0x1c, 0x00, 0x00, 0x00,
+        0x4e, 0x4f, 0x44, 0x45, 0x00, 0x00, 0x00, 0x00, 0x80, 0xff, 0xfe, 0xfd,
       ]),
       expectedMime: "model/gltf-binary",
     },

--- a/tests/routes/health.test.ts
+++ b/tests/routes/health.test.ts
@@ -5,5 +5,5 @@ it("GET /health should return ok", async () => {
   const { ky } = await getTestServer()
   const res = await ky.get("health")
   expect(res.status).toBe(200)
-  expect(await res.json()).toEqual({ ok: true })
+  expect(await res.json<any>()).toEqual({ ok: true })
 })

--- a/tests/routes/health.test.ts
+++ b/tests/routes/health.test.ts
@@ -2,8 +2,8 @@ import { it, expect } from "bun:test"
 import { getTestServer } from "tests/fixtures/get-test-server"
 
 it("GET /health should return ok", async () => {
-  const { axios } = await getTestServer()
-  const res = await axios.get("/health")
+  const { ky } = await getTestServer()
+  const res = await ky.get("health")
   expect(res.status).toBe(200)
-  expect(res.data).toEqual({ ok: true })
+  expect(await res.json()).toEqual({ ok: true })
 })

--- a/tests/routes/proxy.test.ts
+++ b/tests/routes/proxy.test.ts
@@ -3,13 +3,12 @@ import { getTestServer } from "../fixtures/get-test-server"
 
 describe("proxy route", () => {
   test("should proxy requests to target URL", async () => {
-    const { axios } = await getTestServer()
+    const { ky } = await getTestServer()
 
-    // Create a mock server for testing proxying
     const mockServerPort = 3999
     const mockServer = Bun.serve({
       port: mockServerPort,
-      fetch(req) {
+      fetch() {
         return new Response(
           JSON.stringify({ message: "Hello from mock server!" }),
           {
@@ -20,33 +19,32 @@ describe("proxy route", () => {
     })
 
     try {
-      const response = await axios.get("/proxy", {
+      const response = await ky.get("proxy", {
         headers: {
           "X-Target-Url": `http://localhost:${mockServerPort}`,
         },
       })
 
       expect(response.status).toBe(200)
-      expect(response.data).toEqual({ message: "Hello from mock server!" })
+      expect(await response.json()).toEqual({ message: "Hello from mock server!" })
     } finally {
       mockServer.stop()
     }
   })
 
   test("should return 400 when X-Target-Url header is missing", async () => {
-    const { axios } = await getTestServer()
+    const { ky } = await getTestServer()
 
-    const response = await axios.get("/proxy", { validateStatus: () => true })
+    const response = await ky.get("proxy")
     expect(response.status).toBe(400)
-    expect(response.data).toEqual({
+    expect(await response.json()).toEqual({
       error: "X-Target-Url header is required",
     })
   })
 
   test("should handle POST requests with a body correctly", async () => {
-    const { axios } = await getTestServer()
+    const { ky } = await getTestServer()
 
-    // Create a mock server that echoes back the request body
     const mockServerPort = 4000
     const mockServer = Bun.serve({
       port: mockServerPort,
@@ -59,7 +57,8 @@ describe("proxy route", () => {
 
     try {
       const testData = { test: "data" }
-      const response = await axios.post("/proxy", testData, {
+      const response = await ky.post("proxy", {
+        json: testData,
         headers: {
           "X-Target-Url": `http://localhost:${mockServerPort}`,
           "Content-Type": "application/json",
@@ -67,7 +66,7 @@ describe("proxy route", () => {
       })
 
       expect(response.status).toBe(200)
-      expect(response.data).toEqual(testData)
+      expect(await response.json()).toEqual(testData)
     } finally {
       mockServer.stop()
     }

--- a/tests/routes/proxy.test.ts
+++ b/tests/routes/proxy.test.ts
@@ -26,7 +26,9 @@ describe("proxy route", () => {
       })
 
       expect(response.status).toBe(200)
-      expect(await response.json<any>()).toEqual({ message: "Hello from mock server!" })
+      expect(await response.json<any>()).toEqual({
+        message: "Hello from mock server!",
+      })
     } finally {
       mockServer.stop()
     }

--- a/tests/routes/proxy.test.ts
+++ b/tests/routes/proxy.test.ts
@@ -26,7 +26,7 @@ describe("proxy route", () => {
       })
 
       expect(response.status).toBe(200)
-      expect(await response.json()).toEqual({ message: "Hello from mock server!" })
+      expect(await response.json<any>()).toEqual({ message: "Hello from mock server!" })
     } finally {
       mockServer.stop()
     }
@@ -37,7 +37,7 @@ describe("proxy route", () => {
 
     const response = await ky.get("proxy")
     expect(response.status).toBe(400)
-    expect(await response.json()).toEqual({
+    expect(await response.json<any>()).toEqual({
       error: "X-Target-Url header is required",
     })
   })
@@ -66,7 +66,7 @@ describe("proxy route", () => {
       })
 
       expect(response.status).toBe(200)
-      expect(await response.json()).toEqual(testData)
+      expect(await response.json<any>()).toEqual(testData)
     } finally {
       mockServer.stop()
     }


### PR DESCRIPTION
/claim #5

Adds focused coverage for both download endpoint styles and migrates the test fixtures from redaxios to ky.

This validates:
- `/files/download?file_path=...`
- `/files/download/{file_path}`
- proxied text, JSON, and binary downloads