### PR TITLE
fix: keep disk proxy reads inside proxy root

### DIFF
--- a/lib/utils/resolve-file-proxy.ts
+++ b/lib/utils/resolve-file-proxy.ts
@@ -1,6 +1,6 @@
 import type { FileProxy } from "../db/schema"
 import { readFile } from "node:fs/promises"
-import { join } from "node:path"
+import { isAbsolute, relative, resolve, sep } from "node:path"
 import { normalizePath } from "./normalize-path"
 
 export async function resolveFileProxy(
@@ -26,7 +26,17 @@ async function resolveDiskProxy(
   diskPath: string,
   relativePath: string,
 ): Promise<Response> {
-  const fullPath = join(diskPath, relativePath)
+  const proxyRoot = resolve(diskPath)
+  const fullPath = resolve(proxyRoot, relativePath)
+  const pathFromRoot = relative(proxyRoot, fullPath)
+
+  if (
+    pathFromRoot === ".." ||
+    pathFromRoot.startsWith(`..${sep}`) ||
+    isAbsolute(pathFromRoot)
+  ) {
+    return new Response("File not found", { status: 404 })
+  }
 
   try {
     const content = await readFile(fullPath)

--- a/tests/routes/file-proxy02.test.ts
+++ b/tests/routes/file-proxy02.test.ts
@@ -91,6 +91,42 @@ test("disk proxy with query param download", async () => {
   }
 })
 
+test("disk proxy blocks paths outside proxy root", async () => {
+  const { axios } = await getTestServer()
+
+  const tempDir = await mkdtemp(join(tmpdir(), "file-proxy-root-test-"))
+  const proxyRoot = join(tempDir, "public")
+
+  try {
+    await mkdir(proxyRoot)
+    await writeFile(join(proxyRoot, "allowed.txt"), "Allowed content")
+    await writeFile(join(tempDir, "secret.txt"), "Secret content")
+
+    await axios.post("/file_proxies/create", {
+      proxy_type: "disk",
+      disk_path: proxyRoot,
+      matching_pattern: "safe-disk/*",
+    })
+
+    const allowedRes = await axios.get("/files/download", {
+      params: { file_path: "/safe-disk/allowed.txt" },
+    })
+    expect(allowedRes.status).toBe(200)
+    expect(allowedRes.data).toBe("Allowed content")
+
+    await expect(
+      axios.get("/files/download", {
+        params: { file_path: "/safe-disk/../secret.txt" },
+      }),
+    ).rejects.toMatchObject({
+      status: 404,
+      data: "File not found",
+    })
+  } finally {
+    await rm(tempDir, { recursive: true, force: true })
+  }
+})
+
 test("disk proxy binary file", async () => {
   const { axios } = await getTestServer()
 


### PR DESCRIPTION
Fixes a disk proxy path containment issue.

The disk proxy previously joined the configured proxy root with the requested relative path without verifying the resolved result stayed inside the proxy root. This patch resolves both paths, checks the relative path remains within the root, and returns the existing 404 response for out-of-root requests.

Verification:
- npx tsc --noEmit
- npx --yes bun test tests/routes/file-proxy02.test.ts