### PR TITLE
Document and cover file download endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,23 @@ Response: {
 }
 ```
 
+#### Download File
+
+```http
+GET /files/download?file_id=1
+# or
+GET /files/download?file_path=path/to/file.txt
+# or
+GET /files/download/path/to/file.txt
+
+Response: raw file contents with a Content-Disposition attachment header.
+```
+
+Use the download endpoints when you want a browser-friendly attachment URL
+instead of the JSON metadata returned by `/files/get`. Text files are returned as
+`text/plain`; binary files are decoded from `binary_content_b64` and returned as
+`application/octet-stream` with a `Content-Length` header.
+
 #### List Files
 
 ```http

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,6 @@
       "name": "@tscircuit/file-server",
       "dependencies": {
         "winterspec": "^0.0.86",
-        "zod": "^3.23.8",
         "zustand": "^4.5.5",
         "zustand-hoist": "^2.0.1",
       },
@@ -16,9 +15,11 @@
         "next": "^14.2.5",
         "redaxios": "^0.5.1",
         "tsup": "^8.3.5",
+        "zod": "^3.23.8",
       },
       "peerDependencies": {
         "typescript": "^5.0.0",
+        "zod": "*",
       },
     },
   },

--- a/routes/index.ts
+++ b/routes/index.ts
@@ -13,6 +13,8 @@ This is a simple file server API, it has the following API:
 
 /health - Health check
 /files/get?file_path=... - Get a file
+/files/download?file_path=... - Download a file as an attachment
+/files/download/path/to/file.txt - Download a file path as an attachment
 /files/list - List all files
 /files/upsert - Upsert a file
 

--- a/tests/routes/files.test.ts
+++ b/tests/routes/files.test.ts
@@ -65,7 +65,7 @@ test("binary file operations", async () => {
 test("file download operations", async () => {
   const { axios } = await getTestServer()
 
-  await axios.post("/files/upsert", {
+  const createRes = await axios.post("/files/upsert", {
     file_path: "/download-test.txt",
     text_content: "Test download content",
   })
@@ -77,6 +77,15 @@ test("file download operations", async () => {
   expect(successRes.data).toBe("Test download content")
   expect(successRes.headers.get("content-type")).toBe("text/plain")
   expect(successRes.headers.get("content-disposition")).toBe(
+    'attachment; filename="download-test.txt"',
+  )
+
+  const downloadByIdRes = await axios.get("/files/download", {
+    params: { file_id: createRes.data.file.file_id },
+  })
+  expect(downloadByIdRes.status).toBe(200)
+  expect(downloadByIdRes.data).toBe("Test download content")
+  expect(downloadByIdRes.headers.get("content-disposition")).toBe(
     'attachment; filename="download-test.txt"',
   )
 
@@ -110,6 +119,25 @@ test("file download operations2", async () => {
     status: 404,
     data: "File not found",
   })
+})
+
+test("nested file download path preserves subdirectories", async () => {
+  const { axios } = await getTestServer()
+
+  await axios.post("/files/upsert", {
+    file_path: "/nested/path/download-test3.txt",
+    text_content: "Nested download content",
+  })
+
+  const successRes = await axios.get(
+    "/files/download/nested/path/download-test3.txt",
+  )
+  expect(successRes.status).toBe(200)
+  expect(successRes.data).toBe("Nested download content")
+  expect(successRes.headers.get("content-type")).toBe("text/plain")
+  expect(successRes.headers.get("content-disposition")).toBe(
+    'attachment; filename="download-test3.txt"',
+  )
 })
 
 test("file delete operations", async () => {


### PR DESCRIPTION
/claim #5

## Summary
- Document both browser-friendly download URL styles in the README and root API index.
- Add coverage for downloading by `file_id` through `/files/download`.
- Add coverage for nested path downloads through `/files/download/{file_path}`.

## Validation
- `bun test tests/routes/files.test.ts`
- `bun x tsc --noEmit`
- `bun run format:check && git diff --check`

Note: `bun run build` currently fails on Windows because winterspec/esbuild receives unescaped backslashes in generated route imports, for example `C:\root\work\tscircuit-file-server-5\routes\files\upsert.ts`.