### PR TITLE
fix: prefer most specific file proxy match

### DIFF
--- a/lib/db/db-client.ts
+++ b/lib/db/db-client.ts
@@ -247,6 +247,8 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
   matchFileProxy: (file_path: string): FileProxy | undefined => {
     const state = get()
     const normalizedPath = normalizePath(file_path)
+    const matchingProxies: Array<{ proxy: FileProxy; prefixLength: number }> =
+      []
 
     for (const proxy of state.file_proxies) {
       const pattern = proxy.matching_pattern
@@ -254,10 +256,12 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
       if (pattern.endsWith("/*")) {
         const prefix = pattern.slice(0, -1) // Remove the "*" to get "prefix/"
         if (normalizedPath.startsWith(prefix)) {
-          return proxy
+          matchingProxies.push({ proxy, prefixLength: prefix.length })
         }
       }
     }
-    return undefined
+
+    matchingProxies.sort((a, b) => b.prefixLength - a.prefixLength)
+    return matchingProxies[0]?.proxy
   },
 }))

--- a/tests/routes/file-proxy04.test.ts
+++ b/tests/routes/file-proxy04.test.ts
@@ -114,6 +114,45 @@ test("multiple proxies with different patterns", async () => {
   }
 })
 
+test("most specific proxy pattern wins for overlapping prefixes", async () => {
+  const { axios } = await getTestServer()
+
+  const broadDir = await mkdtemp(join(tmpdir(), "file-proxy-broad-"))
+  const specificDir = await mkdtemp(join(tmpdir(), "file-proxy-specific-"))
+
+  try {
+    await writeFile(
+      join(broadDir, "private-file.txt"),
+      "Content from broad proxy",
+    )
+    await writeFile(
+      join(specificDir, "private-file.txt"),
+      "Content from specific proxy",
+    )
+
+    await axios.post("/file_proxies/create", {
+      proxy_type: "disk",
+      disk_path: broadDir,
+      matching_pattern: "overlap/*",
+    })
+
+    await axios.post("/file_proxies/create", {
+      proxy_type: "disk",
+      disk_path: specificDir,
+      matching_pattern: "overlap/private/*",
+    })
+
+    const res = await axios.get(
+      "/files/download/overlap/private/private-file.txt",
+    )
+    expect(res.status).toBe(200)
+    expect(res.data).toBe("Content from specific proxy")
+  } finally {
+    await rm(broadDir, { recursive: true, force: true })
+    await rm(specificDir, { recursive: true, force: true })
+  }
+})
+
 test("no proxy match returns 404", async () => {
   const { axios } = await getTestServer()
 


### PR DESCRIPTION
## Summary
- prefer the longest matching file proxy prefix when multiple proxy patterns match
- keep database files taking precedence before proxy fallback
- add regression coverage for broad-first overlapping disk proxies

## Validation
- bun test tests/routes/file-proxy04.test.ts
- bun test
- bunx tsc --noEmit
- bun run format:check
- bun run build
- git diff --check

/claim #5