### PR TITLE
fix: normalize all repeated path slashes

### DIFF
--- a/lib/utils/normalize-path.ts
+++ b/lib/utils/normalize-path.ts
@@ -1,6 +1,6 @@
 export function normalizePath(path: string): string {
   if (!path || path === "/") return ""
-  let normalized = path.replace(/\\+/g, "/").replace(/\/\/+/, "/")
+  let normalized = path.replace(/\\+/g, "/").replace(/\/\/+/g, "/")
   if (normalized.startsWith("/")) {
     normalized = normalized.slice(1)
   }

--- a/tests/fixtures/get-test-server.ts
+++ b/tests/fixtures/get-test-server.ts
@@ -10,16 +10,15 @@ interface TestFixture {
 }
 
 export const getTestServer = async (): Promise<TestFixture> => {
-  const port = 3001 + Math.floor(Math.random() * 999)
   const testInstanceId = Math.random().toString(36).substring(2, 15)
   const testDbName = `testdb${testInstanceId}`
 
   const server = await startServer({
-    port,
+    port: 0,
     testDbName,
   })
 
-  const url = `http://127.0.0.1:${port}`
+  const url = `http://127.0.0.1:${server.port}`
   const axios = defaultAxios.create({
     baseURL: url,
   })

--- a/tests/routes/files.test.ts
+++ b/tests/routes/files.test.ts
@@ -112,6 +112,22 @@ test("file download operations2", async () => {
   })
 })
 
+test("download query paths normalize every repeated slash run", async () => {
+  const { axios } = await getTestServer()
+
+  await axios.post("/files/upsert", {
+    file_path: "/normalized/path/file.txt",
+    text_content: "Normalized repeated slashes",
+  })
+
+  const downloadRes = await axios.get("/files/download", {
+    params: { file_path: "/normalized//path///file.txt" },
+  })
+
+  expect(downloadRes.status).toBe(200)
+  expect(downloadRes.data).toBe("Normalized repeated slashes")
+})
+
 test("file delete operations", async () => {
   const { axios } = await getTestServer()
 


### PR DESCRIPTION
## Summary
- collapse every repeated slash run during path normalization, not just the first one
- keep download query lookups consistent for paths containing multiple duplicate slash groups
- add regression coverage for `/files/download?file_path=...`
- make test servers bind to OS-assigned ports so parallel CI runs do not collide

## Validation
- bun test tests/routes/files.test.ts
- bun test && bun test && bun test
- bunx tsc --noEmit
- bun run format:check
- bun run build
- git diff --check

/claim #5