### PR TITLE
fix: serve zero-byte binary files correctly

### DIFF
--- a/routes/files/download.ts
+++ b/routes/files/download.ts
@@ -28,7 +28,7 @@ export default withRouteSpec({
   }
 
   const isText = file.text_content !== undefined
-  if (!isText && file.binary_content_b64) {
+  if (!isText && file.binary_content_b64 !== undefined) {
     const binaryBody = decodeBase64ToUint8Array(file.binary_content_b64)
     const responseBody = uint8ArrayToArrayBuffer(binaryBody)
     return new Response(responseBody, {

--- a/routes/files/download/[[...file_path]].ts
+++ b/routes/files/download/[[...file_path]].ts
@@ -29,7 +29,7 @@ export default withRouteSpec({
   }
 
   const isText = file.text_content !== undefined
-  if (!isText && file.binary_content_b64) {
+  if (!isText && file.binary_content_b64 !== undefined) {
     const binaryBody = decodeBase64ToUint8Array(file.binary_content_b64)
     const responseBody = uint8ArrayToArrayBuffer(binaryBody)
     return new Response(responseBody, {

--- a/routes/files/static/[[...file_path]].ts
+++ b/routes/files/static/[[...file_path]].ts
@@ -81,7 +81,7 @@ export default withRouteSpec({
   }
 
   const mimeType = getMimeType(file.file_path)
-  if (file.binary_content_b64) {
+  if (file.binary_content_b64 !== undefined) {
     const binaryBody = decodeBase64ToUint8Array(file.binary_content_b64)
     const responseBody = uint8ArrayToArrayBuffer(binaryBody)
 

--- a/tests/routes/files.test.ts
+++ b/tests/routes/files.test.ts
@@ -62,6 +62,39 @@ test("binary file operations", async () => {
   )
 })
 
+test("zero-byte binary files download and serve as binary", async () => {
+  const { axios, url } = await getTestServer()
+
+  await axios.post("/files/upsert", {
+    file_path: "/empty.bin",
+    binary_content_b64: "",
+  })
+
+  const queryDownloadRes = await fetch(
+    `${url}/files/download?file_path=${encodeURIComponent("/empty.bin")}`,
+  )
+  expect(queryDownloadRes.status).toBe(200)
+  expect(await queryDownloadRes.arrayBuffer()).toHaveProperty("byteLength", 0)
+  expect(queryDownloadRes.headers.get("content-type")).toBe(
+    "application/octet-stream",
+  )
+  expect(queryDownloadRes.headers.get("content-length")).toBe("0")
+
+  const pathDownloadRes = await fetch(`${url}/files/download/empty.bin`)
+  expect(pathDownloadRes.status).toBe(200)
+  expect(await pathDownloadRes.arrayBuffer()).toHaveProperty("byteLength", 0)
+  expect(pathDownloadRes.headers.get("content-type")).toBe(
+    "application/octet-stream",
+  )
+  expect(pathDownloadRes.headers.get("content-length")).toBe("0")
+
+  const staticRes = await fetch(`${url}/files/static/empty.bin`)
+  expect(staticRes.status).toBe(200)
+  expect(await staticRes.arrayBuffer()).toHaveProperty("byteLength", 0)
+  expect(staticRes.headers.get("content-type")).toBe("application/octet-stream")
+  expect(staticRes.headers.get("content-length")).toBe("0")
+})
+
 test("file download operations", async () => {
   const { axios } = await getTestServer()
 


### PR DESCRIPTION
## Summary
- treat `binary_content_b64: ""` as a valid binary file instead of falling through to the text response path
- cover query download, path download, and static serving for zero-byte binary files

## Validation
- `bun test tests/routes/files.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`
- `git diff --check`

/claim #5