### PR TITLE
fix: escape admin file page values

### DIFF
--- a/lib/utils/escape-html.ts
+++ b/lib/utils/escape-html.ts
@@ -1,0 +1,8 @@
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+}

--- a/routes/admin/files/get.ts
+++ b/routes/admin/files/get.ts
@@ -1,4 +1,5 @@
 import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { escapeHtml } from "lib/utils/escape-html"
 import { z } from "zod"
 
 export default withRouteSpec({
@@ -15,10 +16,16 @@ export default withRouteSpec({
     return new Response("File not found", { status: 404 })
   }
 
+  const encodedPath = file.file_path
+    .split("/")
+    .map(encodeURIComponent)
+    .join("/")
+  const encodedPathWithoutLeadingSlash = encodedPath.replace(/^\/+/, "")
+
   return new Response(
     `<html>
     <head>
-      <title>File Details - ${file.file_path}</title>
+      <title>File Details - ${escapeHtml(file.file_path)}</title>
       <style>
         .container { max-width: 800px; margin: 0 auto; padding: 20px; }
         .details { margin-bottom: 20px; }
@@ -33,20 +40,17 @@ export default withRouteSpec({
         <p><a href="./list">← Back to file list</a></p>
         <h1>File Details</h1>
         <div class="details">
-          <p><span class="label">File ID:</span> ${file.file_id}</p>
-          <p><span class="label">File Path:</span> ${file.file_path}</p>
-          <p><span class="label">Created At:</span> ${file.created_at}</p>
+          <p><span class="label">File ID:</span> ${escapeHtml(file.file_id)}</p>
+          <p><span class="label">File Path:</span> ${escapeHtml(file.file_path)}</p>
+          <p><span class="label">Created At:</span> ${escapeHtml(file.created_at)}</p>
         </div>
         <h2>Links:</h2>
         <ul>
-          <li><a href="../../files/download?file_path=/${file.file_path}">Download File</a></li>
-          <li><a href="../../files/static/${file.file_path}">Static Route</a></li>
+          <li><a href="../../files/download?file_path=/${encodedPathWithoutLeadingSlash}">Download File</a></li>
+          <li><a href="../../files/static/${encodedPathWithoutLeadingSlash}">Static Route</a></li>
         </ul>
         <h2>Content:</h2>
-        <pre>${(file.text_content ?? "[binary content]")
-          .replace(/&/g, "&amp;")
-          .replace(/</g, "&lt;")
-          .replace(/>/g, "&gt;")}</pre>
+        <pre>${escapeHtml(file.text_content ?? "[binary content]")}</pre>
       </div>
     </body>
     </html>`,

--- a/routes/admin/files/list.ts
+++ b/routes/admin/files/list.ts
@@ -1,4 +1,5 @@
 import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { escapeHtml } from "lib/utils/escape-html"
 import { z } from "zod"
 
 export default withRouteSpec({
@@ -32,7 +33,7 @@ export default withRouteSpec({
           .map(
             (file) => `
           <tr>
-            <td>${file.file_path}</td>
+            <td>${escapeHtml(file.file_path)}</td>
             <td>
               <a href="./get?file_path=${encodeURIComponent(file.file_path)}">View Details</a>
             </td>

--- a/tests/routes/admin-files-page.test.ts
+++ b/tests/routes/admin-files-page.test.ts
@@ -19,3 +19,36 @@ test("admin file page shows download and static links", async () => {
   )
   expect(html).toContain('href="../../files/static/admin-link-test.txt"')
 })
+
+test("admin file pages escape untrusted file paths", async () => {
+  const { axios } = await getTestServer()
+
+  const maliciousPath = '/"><script>alert(1)</script>.txt'
+
+  await axios.post("/files/upsert", {
+    file_path: maliciousPath,
+    text_content: '<img src=x onerror="alert(2)">',
+  })
+
+  const listRes = await axios.get("/admin/files/list")
+  const listHtml = listRes.data as string
+
+  expect(listHtml).toContain(
+    "&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;.txt",
+  )
+  expect(listHtml).not.toContain("<script>alert(1)</script>")
+
+  const detailsRes = await axios.get("/admin/files/get", {
+    params: { file_path: maliciousPath },
+  })
+  const detailsHtml = detailsRes.data as string
+
+  expect(detailsHtml).toContain(
+    "&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;.txt",
+  )
+  expect(detailsHtml).toContain(
+    "&lt;img src=x onerror=&quot;alert(2)&quot;&gt;",
+  )
+  expect(detailsHtml).not.toContain("<script>alert(1)</script>")
+  expect(detailsHtml).not.toContain('<img src=x onerror="alert(2)">')
+})


### PR DESCRIPTION
## Summary
- escape untrusted file paths and metadata in admin file list/details HTML
- URL-encode generated admin download/static links while preserving the existing safe link shape
- add a regression for a malicious file path and HTML-looking text content

## Validation
- `bun test tests/routes/admin-files-page.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`
- `git diff --check`

/claim #5