### PR TITLE
fix: escape admin event page values

### DIFF
--- a/routes/admin/events/list.ts
+++ b/routes/admin/events/list.ts
@@ -1,6 +1,15 @@
 import { withRouteSpec } from "lib/middleware/with-winter-spec"
 import { z } from "zod"
 
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+}
+
 export default withRouteSpec({
   methods: ["GET"],
   jsonResponse: z.any(),
@@ -34,13 +43,13 @@ export default withRouteSpec({
               .map(
                 ({ event_type, event_id, created_at, ...rest }) => `
               <tr>
-                <td class="border border-gray-300 p-2">${event_type}</td>
-                <td class="border border-gray-300 p-2">${new Date(
-                  created_at,
-                ).toLocaleString()}</td>
-                <td class="border border-gray-300 p-2">${JSON.stringify(rest)
-                  .slice(1, -1)
-                  .replace(/"([^"]+)":/g, "$1:")}</td>
+                <td class="border border-gray-300 p-2">${escapeHtml(event_type)}</td>
+                <td class="border border-gray-300 p-2">${escapeHtml(new Date(created_at).toLocaleString())}</td>
+                <td class="border border-gray-300 p-2">${escapeHtml(
+                  JSON.stringify(rest)
+                    .slice(1, -1)
+                    .replace(/"([^"]+)":/g, "$1:"),
+                )}</td>
               </tr>
             `,
               )

--- a/tests/routes/admin-events-page.test.ts
+++ b/tests/routes/admin-events-page.test.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("admin events page escapes untrusted event values", async () => {
+  const { axios } = await getTestServer()
+
+  await axios.post("/events/create", {
+    event_type: 'USER_LOGIN"><script>alert(1)</script>',
+    file_path: '/"><img src=x onerror="alert(2)">.txt',
+    initiator: '<svg onload="alert(3)">',
+  })
+
+  const res = await axios.get("/admin/events/list")
+  const html = res.data as string
+
+  expect(html).toContain(
+    "USER_LOGIN&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;",
+  )
+  expect(html).toContain(
+    "file_path:&quot;/\\&quot;&gt;&lt;img src=x onerror=\\&quot;alert(2)\\&quot;&gt;.txt&quot;",
+  )
+  expect(html).toContain(
+    "initiator:&quot;&lt;svg onload=\\&quot;alert(3)\\&quot;&gt;&quot;",
+  )
+  expect(html).not.toContain("<script>alert(1)</script>")
+  expect(html).not.toContain('<img src=x onerror="alert(2)">')
+  expect(html).not.toContain('<svg onload="alert(3)">')
+})


### PR DESCRIPTION
## Summary
- escape untrusted event type and event detail values in `/admin/events/list`
- cover custom event payloads that would otherwise render scriptable HTML
- keep the change scoped to admin event rendering

## Validation
- `bun test tests/routes/admin-events-page.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`
- `git diff --check`

/claim #5