### PR TITLE
fix: correct admin dashboard links

### DIFF
--- a/routes/admin/index.ts
+++ b/routes/admin/index.ts
@@ -17,10 +17,10 @@ export default withRouteSpec({
         <nav>
           <ul class="space-y-4">
             <li>
-              <a href="./admin/files/list" class="block px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors">File Management</a>
+              <a href="./files/list" class="block px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors">File Management</a>
             </li>
             <li>
-              <a href="./admin/events/list" class="block px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors">Event Management</a>
+              <a href="./events/list" class="block px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors">Event Management</a>
             </li>
           </ul>
         </nav>

--- a/tests/fixtures/get-test-server.ts
+++ b/tests/fixtures/get-test-server.ts
@@ -1,5 +1,4 @@
 import { afterEach } from "bun:test"
-import { tmpdir } from "node:os"
 import defaultAxios from "redaxios"
 import { startServer } from "./start-server"
 
@@ -10,16 +9,15 @@ interface TestFixture {
 }
 
 export const getTestServer = async (): Promise<TestFixture> => {
-  const port = 3001 + Math.floor(Math.random() * 999)
   const testInstanceId = Math.random().toString(36).substring(2, 15)
   const testDbName = `testdb${testInstanceId}`
 
   const server = await startServer({
-    port,
+    port: 0,
     testDbName,
   })
 
-  const url = `http://127.0.0.1:${port}`
+  const url = `http://127.0.0.1:${server.port}`
   const axios = defaultAxios.create({
     baseURL: url,
   })

--- a/tests/routes/admin-index.test.ts
+++ b/tests/routes/admin-index.test.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("admin dashboard links resolve to existing admin routes", async () => {
+  const { axios } = await getTestServer()
+
+  const res = await axios.get("/admin")
+  const html = res.data as string
+
+  expect(html).toContain('href="./files/list"')
+  expect(html).toContain('href="./events/list"')
+  expect(html).not.toContain('href="./admin/files/list"')
+  expect(html).not.toContain('href="./admin/events/list"')
+
+  const filesRes = await axios.get("/admin/files/list")
+  expect(filesRes.status).toBe(200)
+
+  const eventsRes = await axios.get("/admin/events/list")
+  expect(eventsRes.status).toBe(200)
+})


### PR DESCRIPTION
## Summary
- fix `/admin` dashboard links so they resolve to existing admin routes
- add coverage that the dashboard points to `/admin/files/list` and `/admin/events/list` instead of `/admin/admin/...`

## Validation
- `bun test tests/routes/admin-index.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`
- `git diff --check`

/claim #5