### PR TITLE
fix: normalize file proxy patterns

### DIFF
--- a/lib/db/db-client.ts
+++ b/lib/db/db-client.ts
@@ -213,9 +213,13 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
     proxy: Omit<FileProxy, "file_proxy_id" | "created_at">,
   ): FileProxy => {
     let newProxy: FileProxy
+    const normalizedProxy = {
+      ...proxy,
+      matching_pattern: normalizeMatchingPattern(proxy.matching_pattern),
+    }
     set((state) => {
       newProxy = {
-        ...proxy,
+        ...normalizedProxy,
         file_proxy_id: state.idCounter.toString(),
         created_at: new Date().toISOString(),
       } as FileProxy
@@ -232,11 +236,13 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
     matching_pattern?: string
   }): FileProxy | undefined => {
     const state = get()
+    const matchingPattern = query.matching_pattern
+      ? normalizeMatchingPattern(query.matching_pattern)
+      : undefined
     return state.file_proxies.find(
       (p) =>
         (query.file_proxy_id && p.file_proxy_id === query.file_proxy_id) ||
-        (query.matching_pattern &&
-          p.matching_pattern === query.matching_pattern),
+        (matchingPattern && p.matching_pattern === matchingPattern),
     )
   },
 
@@ -261,3 +267,11 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
     return undefined
   },
 }))
+
+function normalizeMatchingPattern(matching_pattern: string): string {
+  if (!matching_pattern.endsWith("/*")) {
+    return normalizePath(matching_pattern)
+  }
+
+  return `${normalizePath(matching_pattern.slice(0, -2))}/*`
+}

--- a/tests/routes/file-proxy01.test.ts
+++ b/tests/routes/file-proxy01.test.ts
@@ -93,3 +93,33 @@ test("file proxy create validation - duplicate pattern", async () => {
     status: 400,
   })
 })
+
+test("file proxy patterns normalize leading slashes for lookup and duplicates", async () => {
+  const { axios } = await getTestServer()
+
+  const createRes = await axios.post("/file_proxies/create", {
+    proxy_type: "disk",
+    disk_path: "/tmp/test",
+    matching_pattern: "/normalized/*",
+  })
+  expect(createRes.status).toBe(200)
+  expect(createRes.data.file_proxy.matching_pattern).toBe("normalized/*")
+
+  const getWithLeadingSlash = await axios.get("/file_proxies/get", {
+    params: { matching_pattern: "/normalized/*" },
+  })
+  expect(getWithLeadingSlash.status).toBe(200)
+  expect(getWithLeadingSlash.data.file_proxy.file_proxy_id).toBe(
+    createRes.data.file_proxy.file_proxy_id,
+  )
+
+  await expect(
+    axios.post("/file_proxies/create", {
+      proxy_type: "http",
+      http_target_url: "https://example.com",
+      matching_pattern: "normalized/*",
+    }),
+  ).rejects.toMatchObject({
+    status: 400,
+  })
+})

--- a/tests/routes/file-proxy04.test.ts
+++ b/tests/routes/file-proxy04.test.ts
@@ -149,14 +149,14 @@ test("proxy pattern with leading slash normalization", async () => {
   try {
     await writeFile(join(tempDir, "normalized.txt"), "Normalized path content")
 
-    // Create proxy with pattern (without leading slash in pattern)
+    // Create proxy with a leading slash in the pattern
     await axios.post("/file_proxies/create", {
       proxy_type: "disk",
       disk_path: tempDir,
-      matching_pattern: "slash-test/*",
+      matching_pattern: "/slash-test/*",
     })
 
-    // Should work with leading slash in the request path
+    // Should normalize the proxy pattern and match the request path
     const res = await axios.get("/files/download/slash-test/normalized.txt")
     expect(res.status).toBe(200)
     expect(res.data).toBe("Normalized path content")


### PR DESCRIPTION
## Summary
- normalize file proxy `matching_pattern` values before storing and lookup
- make `/prefix/*` and `prefix/*` behave identically for proxy matching
- reject duplicate proxy patterns across normalized forms

## Validation
- `bun test tests/routes/file-proxy01.test.ts tests/routes/file-proxy04.test.ts`
- `bun test`
- `bunx tsc --noEmit`
- `bun run format:check`
- `bun run build`
- `git diff --check`

/claim #5