### PR TITLE
docs: document download endpoints in API index page

### DIFF
--- a/routes/index.ts
+++ b/routes/index.ts
@@ -15,6 +15,8 @@ This is a simple file server API, it has the following API:
 /files/get?file_path=... - Get a file
 /files/list - List all files
 /files/upsert - Upsert a file
+/files/download?file_path=... - Download a file (query param)
+/files/download/[[file_path]] - Download a file (path-based)
 
 /events/list?since=... - List events since a given timestamp
 /events/list?event_type=... - List events filtered by event type


### PR DESCRIPTION
## Summary

Documents the download endpoints in the API index page.

Both `/files/download?file_path=...` (query param) and `/files/download/[[file_path]]` (path-based) endpoints were already implemented in `routes/files/download.ts` and `routes/files/download/[[...file_path]].ts` respectively, but they were not listed in the API documentation on the index page.

## Changes

- `routes/index.ts`: Added download endpoints to the API documentation list

Closes #5

/claim #5
