### PR TITLE
add proxy cookie leak repro test

### DIFF
--- a/tests/routes/proxy.test.ts
+++ b/tests/routes/proxy.test.ts
@@ -73,33 +73,36 @@ describe("proxy route", () => {
     }
   })
 
-  test("should not forward proxy-origin cookies to the target", async () => {
-    const { axios } = await getTestServer()
+  test.failing(
+    "should not forward proxy-origin cookies to the target",
+    async () => {
+      const { axios } = await getTestServer()
 
-    const mockServerPort = 4001
-    const mockServer = Bun.serve({
-      port: mockServerPort,
-      fetch(req) {
-        return Response.json({
-          cookie: req.headers.get("cookie"),
-        })
-      },
-    })
-
-    try {
-      const response = await axios.get("/proxy", {
-        headers: {
-          "X-Target-Url": `http://localhost:${mockServerPort}`,
-          "X-Sender-Cookie": "",
-          Cookie:
-            'ph_test_posthog={"distinct_id":"localhost-user","session_id":"localhost-session"}',
+      const mockServerPort = 4001
+      const mockServer = Bun.serve({
+        port: mockServerPort,
+        fetch(req) {
+          return Response.json({
+            cookie: req.headers.get("cookie"),
+          })
         },
       })
 
-      expect(response.status).toBe(200)
-      expect(response.data.cookie).toBeNull()
-    } finally {
-      mockServer.stop()
-    }
-  })
+      try {
+        const response = await axios.get("/proxy", {
+          headers: {
+            "X-Target-Url": `http://localhost:${mockServerPort}`,
+            "X-Sender-Cookie": "",
+            Cookie:
+              'ph_test_posthog={"distinct_id":"localhost-user","session_id":"localhost-session"}',
+          },
+        })
+
+        expect(response.status).toBe(200)
+        expect(response.data.cookie).toBeNull()
+      } finally {
+        mockServer.stop()
+      }
+    },
+  )
 })

--- a/tests/routes/proxy.test.ts
+++ b/tests/routes/proxy.test.ts
@@ -72,4 +72,34 @@ describe("proxy route", () => {
       mockServer.stop()
     }
   })
+
+  test("should not forward proxy-origin cookies to the target", async () => {
+    const { axios } = await getTestServer()
+
+    const mockServerPort = 4001
+    const mockServer = Bun.serve({
+      port: mockServerPort,
+      fetch(req) {
+        return Response.json({
+          cookie: req.headers.get("cookie"),
+        })
+      },
+    })
+
+    try {
+      const response = await axios.get("/proxy", {
+        headers: {
+          "X-Target-Url": `http://localhost:${mockServerPort}`,
+          "X-Sender-Cookie": "",
+          Cookie:
+            'ph_test_posthog={"distinct_id":"localhost-user","session_id":"localhost-session"}',
+        },
+      })
+
+      expect(response.status).toBe(200)
+      expect(response.data.cookie).toBeNull()
+    } finally {
+      mockServer.stop()
+    }
+  })
 })


### PR DESCRIPTION
## Summary

- add a regression test to the existing proxy route test suite
- send a synthetic localhost PostHog cookie through `/proxy`
- assert that the target server does not receive the proxy-origin cookie
- mark the known regression with Bun's `test.failing` so the suite remains green
- keep the reproduction fully local and deterministic

## Why

The proxy starts with a copy of every incoming request header. When `X-Sender-Cookie` is empty, the browser's localhost `Cookie` header remains in that copy and is forwarded to the target. EasyEDA's CloudFront/WAF rejects the unexpected cookie with `403 Forbidden`, preventing standard USB-C connector data from loading in `tsci dev`.

This is a file-server boundary issue: the CLI exposes this route by consuming `@tscircuit/file-server`, while runframe only supplies the proxy endpoint.

## Expected-failure behavior

The assertion describes the correct behavior: the target should receive no proxy-origin cookie. `test.failing` records that the current implementation violates the assertion without failing CI. Once the proxy is fixed, Bun will report the unexpected pass, prompting the test to be converted to a normal `test`.

## Validation

- `bun test` — 30 pass, 0 fail
- `bun run format:check` — passes
- `bunx tsc --noEmit` — passes
- `bun run build` — passes
