### PR TITLE
prevent proxy cookie leakage

### DIFF
--- a/routes/proxy.ts
+++ b/routes/proxy.ts
@@ -57,6 +57,9 @@ export default withRouteSpec({
 
   // Add support for X-Sender-Cookie
   const senderCookie = req.headers.get("X-Sender-Cookie")
+  // Browser requests to the proxy can include cookies scoped to the proxy
+  // origin. Only forward a cookie that was explicitly supplied for the target.
+  headers.delete("Cookie")
   if (senderCookie) {
     headers.set("Cookie", senderCookie)
   }

--- a/tests/routes/proxy.test.ts
+++ b/tests/routes/proxy.test.ts
@@ -72,4 +72,63 @@ describe("proxy route", () => {
       mockServer.stop()
     }
   })
+
+  test("should not forward proxy-origin cookies to the target", async () => {
+    const { axios } = await getTestServer()
+
+    const mockServerPort = 4001
+    const mockServer = Bun.serve({
+      port: mockServerPort,
+      fetch(req) {
+        return Response.json({
+          cookie: req.headers.get("cookie"),
+        })
+      },
+    })
+
+    try {
+      const response = await axios.get("/proxy", {
+        headers: {
+          "X-Target-Url": `http://localhost:${mockServerPort}`,
+          "X-Sender-Cookie": "",
+          Cookie:
+            'ph_test_posthog={"distinct_id":"localhost-user","session_id":"localhost-session"}',
+        },
+      })
+
+      expect(response.status).toBe(200)
+      expect(response.data.cookie).toBeNull()
+    } finally {
+      mockServer.stop()
+    }
+  })
+
+  test("should forward an explicitly supplied target cookie", async () => {
+    const { axios } = await getTestServer()
+
+    const mockServerPort = 4002
+    const mockServer = Bun.serve({
+      port: mockServerPort,
+      fetch(req) {
+        return Response.json({
+          cookie: req.headers.get("cookie"),
+        })
+      },
+    })
+
+    try {
+      const response = await axios.get("/proxy", {
+        headers: {
+          "X-Target-Url": `http://localhost:${mockServerPort}`,
+          "X-Sender-Cookie": "target_session=valid",
+          Cookie: "localhost_session=unrelated",
+        },
+      })
+
+      expect(response.status).toBe(200)
+      expect(response.data.cookie).toBe("target_session=valid")
+    } finally {
+      mockServer.stop()
+    }
+  })
 })


### PR DESCRIPTION
## Summary

- prevent cookies scoped to the proxy origin from being forwarded to the target
- continue forwarding cookies explicitly supplied through `X-Sender-Cookie`
- add passing regression coverage for both behaviors

## Root cause

The proxy initializes its outbound headers by copying the incoming browser
request. A request to the local `/proxy` route can therefore contain cookies
scoped to localhost. When `X-Sender-Cookie` is empty, the copied `Cookie`
header was left untouched and forwarded to EasyEDA, whose CloudFront/WAF can
reject the unexpected cookie with `403 Forbidden`.

## Fix

The proxy now removes the incoming `Cookie` header before constructing the
target request. It then restores `Cookie` only when the caller explicitly
provides a non-empty `X-Sender-Cookie`.

This keeps proxy-origin state isolated while preserving the existing contract
for target-specific authenticated requests.

## Why file-server

Runframe supplies target headers through the `X-Sender-*` contract, and the CLI
mounts file-server's proxy route. File-server is the component that converts
the browser request into the target request, so it is the shared boundary that
must distinguish proxy-origin cookies from target cookies.

## Validation

- `bun test tests/routes/proxy.test.ts tests/routes/file-proxy03.test.ts` — 9
  pass, 0 fail
- `bun test --max-concurrency=1` — 31 pass, 0 fail
- `bun run format:check` — passes
- `bunx tsc --noEmit` — passes
- `bun run build` — passes

The repository's default concurrent full-suite run also exposed an unrelated
pre-existing test-isolation flake in the events/file-proxy tests; the affected
tests pass when isolated and the proxy regression is consistently green.
